### PR TITLE
Masking gradient & second derivative.

### DIFF
--- a/tests/common/calibrations/2022-02-04-GCcal.json
+++ b/tests/common/calibrations/2022-02-04-GCcal.json
@@ -2,7 +2,7 @@
     "TCD1": {
         "id": 0,
         "peakdetect": {
-            "window": 3,
+            "window": 5,
             "polyorder": 3,
             "prominence": 10,
             "threshold": 10
@@ -18,7 +18,7 @@
     "TCD2": {
         "id": 1,
         "peakdetect": {
-            "window": 3,
+            "window": 5,
             "polyorder": 3,
             "prominence": 10,
             "threshold": 10

--- a/tests/test_gctrace.py
+++ b/tests/test_gctrace.py
@@ -172,7 +172,7 @@ def special_datagram_test(datagram, testspec):
                 "nrows": 12,
                 "method": "AS_Cal_20220204",
                 "point": 4,
-                "xout": {"CH4": {"n": 0.0578874, "s": 0.0015256, "u": " "}},
+                "xout": {"CH4": {"n": 0.0587991, "s": 0.0015389, "u": " "}},
             },
         ),
     ],


### PR DESCRIPTION
This PR should resolve the instability in `chromtrace`s integration by masking near-zero values of the gradient/hessian.