### PR TITLE
Add `--archive` to `yadg preset`

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -44,10 +44,20 @@ Alternatively, if the `dataschema` should be processed immediately, the ``--proc
 
 .. code-block:: bash
 
-    yadg preset -p infile folder [outfile]
+    yadg preset -p infile folder [outfile.json]
 
 This syntax will process the created `dataschema` immediately, and the `datagram` will 
-be saved to ``outfile`` instead.
+be saved to ``outfile.json`` instead.
+
+Finally, the raw data files in the processed ``folder`` can be archived, checksumed,
+and referenced in the `datagram`, by using the following pattern:
+
+.. code-block:: bash
+
+    yadg preset -p -a infile folder [outfile.json]
+
+This will create a `datagram` in ``outfile.json`` as well as a ``outfile.zip`` archive
+from the whole contents of the specified ``folder``.
 
 Version updater
 ```````````````

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
             "pytest"
         ],
         "docs": [
-            "sphinx",
+            "sphinx>=4<5",
             "sphinx-rtd-theme",
             "sphinx-autodoc-typehints",
             "autodoc-pydantic"

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
             "pytest"
         ],
         "docs": [
-            "sphinx>=4<5",
+            "sphinx==4.5.0",
             "sphinx-rtd-theme",
             "sphinx-autodoc-typehints",
             "autodoc-pydantic"

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -93,18 +93,25 @@ def run_with_arguments():
 
     preset = subparsers.add_parser("preset")
     preset.add_argument(
-        "--process",
         "-p",
+        "--process",
         action="store_true",
         help="Immediately process the schema created from the preset.",
         default=False,
     )
     preset.add_argument(
-        "--archive",
         "-a",
+        "--archive",
         action="store_true",
         help="Archive the whole preset folder after processing.",
         default=False,
+    )
+    preset.add_argument(
+        "--packwith",
+        nargs="?",
+        choices=["zip", "tar", "bztar", "xztar", "gztar"],
+        help="Select compression algorithm for --archive.",
+        default="zip",
     )
     preset.add_argument(
         "preset",

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -36,15 +36,15 @@ def run_with_arguments():
 
     for p in [parser, verbose]:
         p.add_argument(
-            "-v",
             "--verbose",
+            "-v",
             action="count",
             default=0,
             help="Increase verbosity by one level.",
         )
         p.add_argument(
-            "-q",
             "--quiet",
+            "-q",
             action="count",
             default=0,
             help="Decrease verbosity by one level.",
@@ -97,6 +97,13 @@ def run_with_arguments():
         "-p",
         action="store_true",
         help="Immediately process the schema created from the preset.",
+        default=False,
+    )
+    preset.add_argument(
+        "--archive",
+        "-a",
+        action="store_true",
+        help="Archive the whole preset folder after processing.",
         default=False,
     )
     preset.add_argument(

--- a/src/yadg/subcommands.py
+++ b/src/yadg/subcommands.py
@@ -27,8 +27,10 @@ def _load_file(infile: str) -> dict:
 def _zip_file(folder: str, outpath: str, method: str = "zip") -> str:
     if method in {"zip", "tar"}:
         fn = f"{outpath}.{method}"
-    elif method == {"bztar", "gztar", "xztar"}:
+    elif method in {"bztar", "gztar", "xztar"}:
         fn = f"{outpath}.tar.{method[:2]}"
+        if method == "bztar":
+            fn = f"{fn}2"
     logger.debug("Archiving.")
     shutil.make_archive(outpath, method, root_dir=folder)
     logger.debug("Hashing.")
@@ -158,7 +160,7 @@ def preset(args: argparse.Namespace) -> None:
         if args.archive:
             zipfile = args.outfile.replace(".json", "")
             logger.info("Zipping input folder into '%s'", zipfile)
-            fn, hash = _zip_file(args.folder, zipfile)
+            fn, hash = _zip_file(args.folder, zipfile, method=args.packwith)
             datagram["metadata"]["provenance"]["data"] = {"sha-1": hash, "archive": fn}
         logger.info("Saving datagram to '%s'.", args.outfile)
         with open(args.outfile, "w") as ofile:

--- a/src/yadg/subcommands.py
+++ b/src/yadg/subcommands.py
@@ -23,6 +23,7 @@ def _load_file(infile: str) -> dict:
             raise RuntimeError(f"Filename type not recognised: '{infile}'")
     return obj
 
+
 def _zip_file(folder: str, outpath: str, method: str = "zip") -> str:
     if method in {"zip", "tar"}:
         fn = f"{outpath}.{method}"
@@ -36,7 +37,6 @@ def _zip_file(folder: str, outpath: str, method: str = "zip") -> str:
         for chunk in iter(lambda: f.read(4096), b""):
             m.update(chunk)
     return fn, m.hexdigest()
-
 
 
 def process(args: argparse.Namespace) -> None:
@@ -159,10 +159,7 @@ def preset(args: argparse.Namespace) -> None:
             zipfile = args.outfile.replace(".json", "")
             logger.info("Zipping input folder into '%s'", zipfile)
             fn, hash = _zip_file(args.folder, zipfile)
-            datagram["metadata"]["provenance"]["data"] = {
-                "sha-1": hash,
-                "archive": fn
-            }
+            datagram["metadata"]["provenance"]["data"] = {"sha-1": hash, "archive": fn}
         logger.info("Saving datagram to '%s'.", args.outfile)
         with open(args.outfile, "w") as ofile:
             json.dump(datagram, ofile, indent=1)

--- a/tests/test_yadg.py
+++ b/tests/test_yadg.py
@@ -152,6 +152,7 @@ def test_yadg_preset_with_yml(datadir):
     subprocess.run(command, check=True)
     assert os.path.exists("data_2.dg.json")
 
+
 def test_yadg_preset_archive(datadir):
     os.chdir(datadir)
     command = ["yadg", "preset", "-pa", "data_2.preset.yaml", "data_2", "dg.json"]

--- a/tests/test_yadg.py
+++ b/tests/test_yadg.py
@@ -151,3 +151,10 @@ def test_yadg_preset_with_yml(datadir):
     command = ["yadg", "preset", "-p", "data_2.preset.yaml", "data_2", "data_2.dg.json"]
     subprocess.run(command, check=True)
     assert os.path.exists("data_2.dg.json")
+
+def test_yadg_preset_archive(datadir):
+    os.chdir(datadir)
+    command = ["yadg", "preset", "-pa", "data_2.preset.yaml", "data_2", "dg.json"]
+    subprocess.run(command, check=True)
+    assert os.path.exists("dg.json")
+    assert os.path.exists("dg.zip")

--- a/tests/test_yadg.py
+++ b/tests/test_yadg.py
@@ -153,9 +153,23 @@ def test_yadg_preset_with_yml(datadir):
     assert os.path.exists("data_2.dg.json")
 
 
-def test_yadg_preset_archive(datadir):
+@pytest.mark.parametrize(
+    "packwith, suffix",
+    [
+        (None, "zip"),
+        ("zip", "zip"),
+        ("tar", "tar"),
+        ("gztar", "tar.gz"),
+        ("xztar", "tar.xz"),
+        ("bztar", "tar.bz2"),
+    ],
+)
+def test_yadg_preset_archive(packwith, suffix, datadir):
     os.chdir(datadir)
     command = ["yadg", "preset", "-pa", "data_2.preset.yaml", "data_2", "dg.json"]
+    if packwith is not None:
+        command.append("--packwith")
+        command.append(packwith)
     subprocess.run(command, check=True)
     assert os.path.exists("dg.json")
-    assert os.path.exists("dg.zip")
+    assert os.path.exists(f"dg.{suffix}")


### PR DESCRIPTION
Adds the `--archive` (or `-a`) option to `yadg preset`. By toggling this option, the folder on which the preset is applied will be compressed after processing. Stores a `SHA-1` checksum of the compressed file, and the filename, in the metadata of the datagram. Only works with `yadg preset --process --archive`, as without `--process` the datagram does not get created.

Adds the `--packwith [{zip, tar, bztar, xztar, gztar}]` option, with which the user can specify the compression algorithm to be used. By default, `zip` is used.

Closes #54.