### PR TITLE
`electrochem`: Add `transpose` parameter

### DIFF
--- a/src/yadg/parsers/electrochem/__init__.py
+++ b/src/yadg/parsers/electrochem/__init__.py
@@ -52,11 +52,11 @@ format:
         "{{ col2 }}":
           {n: !!float, s: !!float, u: !!str}
 
-For impedance spectroscopy techniques (PEIS, GEIS), the data is made up
-of spectroscopy traces. The data is thus split into traces by the column
-``"cycle number"`` and each trace is cast into a single timestep. Each trace 
-now corresponds to a spectroscopy scan, indexed by the technique name (PEIS or
-GEIS). The timestep takes the following format:
+For impedance spectroscopy techniques (PEIS, GEIS), the data is by default
+transposed to be made of spectroscopy traces. The data is split into traces using 
+the ``"cycle number"`` column, and each trace is cast into a single timestep. Each 
+trace now corresponds to a spectroscopy scan, indexed by the technique name (PEIS 
+or GEIS). The timestep takes the following format:
 
 .. code-block:: yaml
 
@@ -70,12 +70,8 @@ GEIS). The timestep takes the following format:
             "{{ col2 }}":
                 {n: [!!float, ...], s: [!!float, ...], u: !!str}
 
-.. note::
-
-    The parsed data may contain infinities (i.e. ``float("inf")`` /
-    ``float("-inf")``) or NaNs (i.e. ``float("nan")``). While datagrams 
-    containing NaN and Inf can be exported and read back using python's json 
-    module, they are not strictly valid jsons.
+This behaviour can be toggled off by setting the ``transpose`` parameter to ``False``,
+see :class:`~dgbowl_schemas.yadg.dataschema_4_2.step.ElectroChem.Params`.
 
 .. admonition:: TODO
 
@@ -85,52 +81,6 @@ GEIS). The timestep takes the following format:
     of resolutions and accuracies, with ``math.ulp(n)`` as fallback. The values 
     should be device-specific, and the fallback should be eliminated.
 
-.. admonition:: TODO
-
-    https://github.com/dgbowl/yadg/issues/11
-
-    The "raw" data in electrochemistry files should only contain the raw quantities,
-    that is the ``control_I`` or ``control_V`` and the measured potentials ``Ewe``,
-    ``Ece`` or the measured current ``I``. Analogous quantities should be recorded
-    for PEIS/GEIS. All other columns should be computed by **yadg**.
-
-Metadata
-````````
-The metadata collected from the raw file will depend on the ``filetype``. Currently,
-no metadata is recorded for ``tomato.json`` filetype. For the ``eclab.mpt`` and 
-``eclab.mpr`` filetypes, the metadata will contain a ``settings`` and a ``params`` 
-field:
-
-The ``settings`` field for parsed ``.mpt`` files contains the technique name, a 
-posix timestamp and the raw header lines as found in the file. The ``settings`` 
-from parsed ``.mpr`` files contain the technique and more explicitly parsed 
-information than from ``.mpt`` files, like the "cell characteristics" specified 
-in EC-Lab.
-
-The ``params`` will contain the technique parameter sequences and the
-keys in each sequence will be the same independent of ``filetype``, but
-an :class:`int` value in the ``.mpr`` file may be a :class:`str` when 
-parsed from the corresponding ``.mpt`` file, since the mapping has not 
-yet been reverse engineered.
-
-.. admonition:: TODO
-
-    https://github.com/dgbowl/yadg/issues/12
-
-    In ``.mpr`` files, some technique parameters in the settings module
-    correspond to entries in drop-down lists in EC-Lab. These values are
-    stored as single-byte values in ``.mpr`` files.
-
-The metadata from parsed ``".mpr"`` files also provides the ``"log"``
-which contains more general parameters, like software, firmware and
-server versions, channel number, host address and an acquisition start
-timestamp in Microsoft OLE format. 
-
-.. note::
-
-    If the ``.mpr`` file contains an ``ExtDev`` module (containing parameters
-    of any external sensors plugged into the device), the ``log`` is usually 
-    not present and therefore the full timestamp cannot be calculated.
 
 """
 from .main import process

--- a/src/yadg/parsers/electrochem/eclabmpr.py
+++ b/src/yadg/parsers/electrochem/eclabmpr.py
@@ -42,11 +42,11 @@ sequences can be parsed:
 +------+-------------------------------------------------+
 
 
-File Structure of `.mpr` Files
-``````````````````````````````
+File Structure of ``.mpr`` Files
+````````````````````````````````
 
-At a top level, `.mpr` files are made up of a number of modules,
-separated by the `MODULE` keyword. In all the files I have seen, the
+At a top level, ``.mpr`` files are made up of a number of modules,
+separated by the ``MODULE`` keyword. In all the files I have seen, the
 first module is the settings module, followed by the data module, the
 log module and then an optional loop module.
 
@@ -62,7 +62,7 @@ log module and then an optional loop module.
     0x???? MODULE                  # Module magic.
     ...                            # Module 4.
 
-After splitting the entire file on `MODULE`, each module starts with a
+After splitting the entire file on ``MODULE``, each module starts with a
 header that is structured like this (offsets from start of module):
 
 .. code-block::
@@ -163,33 +163,30 @@ EC-Lab, etc. Here a quick overview (offsets from start of module data).
     ...               # ???
 
 
-Structure of Parsed Data
-````````````````````````
+Metadata
+````````
+The metadata will contain the information from the *Settings module*. This should
+include information about the technique, as well as any explicitly parsed cell
+characteristics data specified in EC-Lab.
 
-*EIS Techniques (PEIS/GEIS)*
+.. admonition:: TODO
 
-.. code-block:: yaml
+    https://github.com/dgbowl/yadg/issues/12
 
-    - fn   !!str
-    - uts  !!float
-    - raw:
-        traces:
-          "{{ technique name }}":
-            "{{ col1 }}":
-              [!!int, ...]
-            "{{ col2 }}":
-              {n: [!!float, ...], s: [!!float, ...], u: !!str}
+    The mapping between metadata parameters between ``.mpr`` and ``.mpt`` files
+    is not yet complete. In ``.mpr`` files, some technique parameters in the settings 
+    module correspond to entries in drop-down lists in EC-Lab. These values are
+    stored as single-byte values in ``.mpr`` files.
 
-*All Other Techniques*
+The metadata also contains the infromation from the *Log module*, which contains 
+more general parameters, like software, firmware and server versions, channel number, 
+host address and an acquisition start timestamp in Microsoft OLE format. 
 
-.. code-block:: yaml
+.. note::
 
-    - fn   !!str
-    - uts  !!float
-    - raw:
-        "{{ col1 }}":  !!int
-        "{{ col2 }}":
-          {n: !!float, s: !!float, u: !!str}
+    If the ``.mpr`` file contains an ``ExtDev`` module (containing parameters
+    of any external sensors plugged into the device), the ``log`` is usually 
+    not present and therefore the full timestamp cannot be calculated.
 
 .. codeauthor:: Nicolas Vetsch <vetschnicolas@gmail.com>
 """

--- a/src/yadg/parsers/electrochem/eclabmpr.py
+++ b/src/yadg/parsers/electrochem/eclabmpr.py
@@ -801,7 +801,10 @@ def _process_modules(contents: bytes) -> tuple[dict, list, list, dict, dict]:
 
 
 def process(
-    fn: str, encoding: str = "windows-1252", timezone: str = "localtime"
+    fn: str, 
+    encoding: str = "windows-1252", 
+    timezone: str = "localtime",
+    transpose: bool = True,
 ) -> tuple[list, dict, bool]:
     """Processes EC-Lab raw data binary files.
 
@@ -844,7 +847,7 @@ def process(
     timesteps = []
     # If the technique is an impedance spectroscopy, split it into
     # traces at different cycle numbers and put each trace into its own timestep
-    if settings["technique"] in {"PEIS", "GEIS"}:
+    if settings["technique"] in {"PEIS", "GEIS"} and transpose:
         # Grouping by cycle.
         cycles = defaultdict(list)
         for d in data:

--- a/src/yadg/parsers/electrochem/eclabmpr.py
+++ b/src/yadg/parsers/electrochem/eclabmpr.py
@@ -801,8 +801,8 @@ def _process_modules(contents: bytes) -> tuple[dict, list, list, dict, dict]:
 
 
 def process(
-    fn: str, 
-    encoding: str = "windows-1252", 
+    fn: str,
+    encoding: str = "windows-1252",
     timezone: str = "localtime",
     transpose: bool = True,
 ) -> tuple[list, dict, bool]:

--- a/src/yadg/parsers/electrochem/eclabmpt.py
+++ b/src/yadg/parsers/electrochem/eclabmpt.py
@@ -9,44 +9,25 @@ data table.
 A list of techniques supported by this parser is shown in `the techniques table 
 <yadg.parsers.electrochem.eclabmpr.techniques>`_.
 
-File Structure of `.mpt` Files
-``````````````````````````````
+File Structure of ``.mpt`` Files
+````````````````````````````````
 
 These human-readable files are sectioned into headerlines and datalines.
-The header part at is made up of information that can be found in the
-settings, log and loop modules of the binary `.mpr` file.
+The header part of the ``.mpt`` files is made up of information that can be found 
+in the settings, log and loop modules of the binary ``.mpr`` file.
 
 If no header is present, the timestamps will instead be calculated from
-the file's ctime.
+the file's ``mtime()``.
 
 
-Structure of Parsed Data
-````````````````````````
+Metadata
+````````
+The metadata will contain the information from the header of the file. 
 
-*EIS Techniques (PEIS/GEIS)*
+.. note ::
 
-.. code-block:: yaml
-
-    - fn   !!str
-    - uts  !!float
-    - raw:
-        traces:
-          "{{ technique name }}":
-            "{{ col1 }}":
-              [!!int, ...]
-            "{{ col2 }}":
-              {n: [!!float, ...], s: [!!float, ...], u: !!str}
-
-*All Other Techniques*
-
-.. code-block:: yaml
-
-    - fn   !!str
-    - uts  !!float
-    - raw:
-        "{{ col1 }}":  !!int
-        "{{ col2 }}":
-          {n: !!float, s: !!float, u: !!str}
+    The mapping between metadata parameters between ``.mpr`` and ``.mpt`` files
+    is not yet complete.
 
 .. codeauthor:: Nicolas Vetsch <vetschnicolas@gmail.com>
 """

--- a/src/yadg/parsers/electrochem/eclabmpt.py
+++ b/src/yadg/parsers/electrochem/eclabmpt.py
@@ -285,8 +285,8 @@ def _process_data(lines: list[str], Eranges: list[float], Iranges: list[float]) 
 
 
 def process(
-    fn: str, 
-    encoding: str = "windows-1252", 
+    fn: str,
+    encoding: str = "windows-1252",
     timezone: str = "UTC",
     transpose: bool = True,
 ) -> tuple[list, dict, bool]:

--- a/src/yadg/parsers/electrochem/eclabmpt.py
+++ b/src/yadg/parsers/electrochem/eclabmpt.py
@@ -34,7 +34,6 @@ The metadata will contain the information from the header of the file.
 import re
 import logging
 from collections import defaultdict
-from pydantic import BaseModel
 from ...dgutils.dateutils import str_to_uts
 from .eclabtechniques import get_resolution, technique_params, param_from_key
 

--- a/src/yadg/parsers/electrochem/eclabmpt.py
+++ b/src/yadg/parsers/electrochem/eclabmpt.py
@@ -53,6 +53,7 @@ Structure of Parsed Data
 import re
 import logging
 from collections import defaultdict
+from pydantic import BaseModel
 from ...dgutils.dateutils import str_to_uts
 from .eclabtechniques import get_resolution, technique_params, param_from_key
 
@@ -284,7 +285,10 @@ def _process_data(lines: list[str], Eranges: list[float], Iranges: list[float]) 
 
 
 def process(
-    fn: str, encoding: str = "windows-1252", timezone: str = "UTC"
+    fn: str, 
+    encoding: str = "windows-1252", 
+    timezone: str = "UTC",
+    transpose: bool = True,
 ) -> tuple[list, dict, bool]:
     """Processes EC-Lab human-readable text export files.
 
@@ -337,7 +341,7 @@ def process(
     timesteps = []
     # If the technique is an impedance spectroscopy, split it into
     # traces at different cycle numbers and put each trace into its own timestep
-    if settings["technique"] in {"PEIS", "GEIS"}:
+    if settings["technique"] in {"PEIS", "GEIS"} and transpose:
         # Grouping by cycle.
         cycles = defaultdict(list)
         for d in data:

--- a/src/yadg/parsers/electrochem/main.py
+++ b/src/yadg/parsers/electrochem/main.py
@@ -31,10 +31,17 @@ def process(
         implemented parsers all return full date.
 
     """
+    transpose = parameters.transpose if hasattr(parameters, "transpose") else True
     if parameters.filetype == "eclab.mpr":
-        data, meta, fulldate = eclabmpr.process(fn, encoding, timezone)
+        data, meta, fulldate = eclabmpr.process(
+            fn, encoding, timezone, transpose,
+        )
     elif parameters.filetype == "eclab.mpt":
-        data, meta, fulldate = eclabmpt.process(fn, encoding, timezone)
+        data, meta, fulldate = eclabmpt.process(
+            fn, encoding, timezone, transpose,
+        )
     elif parameters.filetype == "tomato.json":
-        data, meta, fulldate = tomatojson.process(fn, encoding, timezone)
+        data, meta, fulldate = tomatojson.process(
+            fn, encoding, timezone, transpose,
+        )
     return data, meta, fulldate

--- a/src/yadg/parsers/electrochem/main.py
+++ b/src/yadg/parsers/electrochem/main.py
@@ -34,14 +34,23 @@ def process(
     transpose = parameters.transpose if hasattr(parameters, "transpose") else True
     if parameters.filetype == "eclab.mpr":
         data, meta, fulldate = eclabmpr.process(
-            fn, encoding, timezone, transpose,
+            fn,
+            encoding,
+            timezone,
+            transpose,
         )
     elif parameters.filetype == "eclab.mpt":
         data, meta, fulldate = eclabmpt.process(
-            fn, encoding, timezone, transpose,
+            fn,
+            encoding,
+            timezone,
+            transpose,
         )
     elif parameters.filetype == "tomato.json":
         data, meta, fulldate = tomatojson.process(
-            fn, encoding, timezone, transpose,
+            fn,
+            encoding,
+            timezone,
+            transpose,
         )
     return data, meta, fulldate

--- a/src/yadg/parsers/electrochem/tomatojson.py
+++ b/src/yadg/parsers/electrochem/tomatojson.py
@@ -48,7 +48,10 @@ I_ranges = {
 
 
 def process(
-    fn: str, encoding: str = "UTF-8", timezone: str = "UTC"
+    fn: str, 
+    encoding: str = "UTF-8", 
+    timezone: str = "UTC",
+    transpose: bool = True,
 ) -> tuple[list, dict, bool]:
     with open(fn, "r") as infile:
         jsdata = json.load(infile)

--- a/src/yadg/parsers/electrochem/tomatojson.py
+++ b/src/yadg/parsers/electrochem/tomatojson.py
@@ -48,8 +48,8 @@ I_ranges = {
 
 
 def process(
-    fn: str, 
-    encoding: str = "UTF-8", 
+    fn: str,
+    encoding: str = "UTF-8",
     timezone: str = "UTC",
     transpose: bool = True,
 ) -> tuple[list, dict, bool]:

--- a/tests/test_electrochem.py
+++ b/tests/test_electrochem.py
@@ -557,33 +557,25 @@ def test_electrochem_tomato(infile, ts, datadir):
     standard_datagram_test(ret, ts)
     pars_datagram_test(ret, ts)
 
+
 @pytest.mark.parametrize(
     "input",
     [
-        {
-            "case": "peis.mpr",
-            "parameters": {"filetype": "eclab.mpr"}
-        },
+        {"case": "peis.mpr", "parameters": {"filetype": "eclab.mpr"}},
         {
             "case": "peis.mpt",
             "encoding": "windows-1252",
-            "parameters": {"filetype": "eclab.mpt"}
+            "parameters": {"filetype": "eclab.mpt"},
         },
-        {
-            "case": "geis.mpr",
-            "parameters": {"filetype": "eclab.mpr"}
-        },
+        {"case": "geis.mpr", "parameters": {"filetype": "eclab.mpr"}},
         {
             "case": "geis.mpt",
             "encoding": "windows-1252",
-            "parameters": {"filetype": "eclab.mpt"}
-        }
-    ]
+            "parameters": {"filetype": "eclab.mpt"},
+        },
+    ],
 )
-@pytest.mark.parametrize(
-    "transpose",
-    [True, False]
-)
+@pytest.mark.parametrize("transpose", [True, False])
 def test_electrochem_transpose(input, transpose, datadir):
     input["parameters"]["transpose"] = transpose
     ret = datagram_from_input(input, "electrochem", datadir, version="4.2")
@@ -595,11 +587,7 @@ def test_electrochem_transpose(input, transpose, datadir):
         nrows = 61
     elif input["case"].startswith("g"):
         nrows = 2528
-    ts = {
-        "nsteps": 1,
-        "step": 0,
-        "nrows": nrows
-    }
+    ts = {"nsteps": 1, "step": 0, "nrows": nrows}
     standard_datagram_test(ret, ts)
     if transpose:
         assert all(["traces" in ts["raw"] for ts in ret["steps"][0]["data"]])

--- a/tests/test_electrochem.py
+++ b/tests/test_electrochem.py
@@ -556,3 +556,52 @@ def test_electrochem_tomato(infile, ts, datadir):
     ret = datagram_from_file(infile, datadir)
     standard_datagram_test(ret, ts)
     pars_datagram_test(ret, ts)
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        {
+            "case": "peis.mpr",
+            "parameters": {"filetype": "eclab.mpr"}
+        },
+        {
+            "case": "peis.mpt",
+            "encoding": "windows-1252",
+            "parameters": {"filetype": "eclab.mpt"}
+        },
+        {
+            "case": "geis.mpr",
+            "parameters": {"filetype": "eclab.mpr"}
+        },
+        {
+            "case": "geis.mpt",
+            "encoding": "windows-1252",
+            "parameters": {"filetype": "eclab.mpt"}
+        }
+    ]
+)
+@pytest.mark.parametrize(
+    "transpose",
+    [True, False]
+)
+def test_electrochem_transpose(input, transpose, datadir):
+    input["parameters"]["transpose"] = transpose
+    ret = datagram_from_input(input, "electrochem", datadir, version="4.2")
+    if transpose and input["case"].startswith("p"):
+        nrows = 1
+    elif input["case"].startswith("p"):
+        nrows = 32
+    if transpose and input["case"].startswith("g"):
+        nrows = 61
+    elif input["case"].startswith("g"):
+        nrows = 2528
+    ts = {
+        "nsteps": 1,
+        "step": 0,
+        "nrows": nrows
+    }
+    standard_datagram_test(ret, ts)
+    if transpose:
+        assert all(["traces" in ts["raw"] for ts in ret["steps"][0]["data"]])
+    else:
+        assert all(["traces" not in ts["raw"] for ts in ret["steps"][0]["data"]])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,7 +125,6 @@ def datagram_from_input(input, parser, datadir, version="4.0"):
         schema = _schema_4_1(input, parser, version)
     elif version in {"4.2"}:
         schema = _schema_4_2(input, parser, version)
-    print(schema)
     os.chdir(datadir)
     ds = to_dataschema(**schema)
     return yadg.core.process_schema(ds)
@@ -135,7 +134,10 @@ def standard_datagram_test(datagram, testspec):
     assert yadg.core.validators.validate_datagram(datagram), "datagram is invalid"
     assert len(datagram["steps"]) == testspec["nsteps"], "wrong number of steps"
     steps = datagram["steps"][testspec["step"]]["data"]
-    assert len(steps) == testspec["nrows"], "wrong number of timesteps in a step"
+    assert len(steps) == testspec["nrows"], (
+        "wrong number of timesteps in a step: "
+        f"ret: {len(steps)}, ref: {testspec['nrows']}"
+    )
     json.dumps(datagram)
 
 


### PR DESCRIPTION
The `transpose` parameter for the `electrochem` parser dictates whether EIS data should be transposed into traces (default, `transpose = True`) or kept as timesteps (`transpose = False`).