### PR TITLE
Warn if current version is not the latest on PyPI.

### DIFF
--- a/docs/source/version.4_2.rst
+++ b/docs/source/version.4_2.rst
@@ -17,7 +17,8 @@ New features since v4.1 are:
 
   - a new :mod:`~yadg.parsers.chromdata` parser for parsing post-processed chromatography data,
   - the :mod:`~yadg.parsers.basiccsv` parser has an additional parameter ``strip``, allowing
-    the user to strip extra characters (such as ``"`` or ``'``) from column headers and data.
+    the user to strip extra characters (such as ``"`` or ``'``) from column headers and data,
+  - :mod:`yadg` will now warn you if a newer version is available on PyPI.
 
 Backwards-incompatible changes include:
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "packaging",
         "python-dateutil",
         "openpyxl>=3.0.0",
+        "requests",
         "dgbowl-schemas>=111",
         # Master branch dgbowl-schemas can be installed by:
         # "dgbowl-schemas @ https://github.com/dgbowl/dgbowl-schemas/tarball/master",

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -9,23 +9,20 @@ from . import subcommands
 
 logger = logging.getLogger(__name__)
 
+
 def version_check(project="yadg"):
     url = f"https://pypi.org/pypi/{project}/json"
     try:
-        res = requests.get(url, timeout = 1)
+        res = requests.get(url, timeout=1)
     except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
-        logger.debug(
-            f"Version check could not proceed due to Exception={e}."
-        )
-        return 
+        logger.debug(f"Version check could not proceed due to Exception={e}.")
+        return
     jsdata = json.loads(res.text)
     versions = sorted([version.parse(i) for i in jsdata["releases"].keys()])
     latest = versions[-1]
     current = version.parse(metadata.version(project))
     if latest > current:
-        logger.warning(
-            "You are using an out-of-date version of '%s'. ", project
-        )
+        logger.warning("You are using an out-of-date version of '%s'. ", project)
         logger.info(
             "The latest version is '%s', the current version is '%s'.", latest, current
         )
@@ -161,7 +158,7 @@ def run_with_arguments():
         default=None,
     )
     preset.set_defaults(func=subcommands.preset)
-    
+
     # parse subparser args
     args, extras = parser.parse_known_args()
     # parse extras for verbose tags
@@ -173,6 +170,6 @@ def run_with_arguments():
     set_loglevel(args.verbose - args.quiet)
 
     version_check()
-    
+
     if "func" in args:
         args.func(args)

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -22,7 +22,7 @@ def version_check(project="yadg"):
     versions = sorted([version.parse(i) for i in jsdata["releases"].keys()])
     latest = versions[-1]
     current = version.parse(metadata.version(project))
-    if latest >= current:
+    if latest > current:
         logger.warning(
             "You are using an out-of-date version of '%s'. ", project
         )


### PR DESCRIPTION
Add a warning to notify users when they're using an out-of-date version of `yadg`. Connection errors should be handled by catching `Timeout` and `ConnectionError` exceptions.