### PR TITLE
Resolve `xr.concat` issues.

### DIFF
--- a/docs/source/version.5_0.rst
+++ b/docs/source/version.5_0.rst
@@ -30,6 +30,8 @@ Backwards-incompatible changes include:
     to update `datagrams` has been removed.
   - The parameter ``transpose`` from :mod:`~yadg.parsers.electrochem` parser is no longer
     available; all electrochemistry data is returned as plain timesteps.
+  - The ``valve`` number in the ``fusion-json`` extractor of :mod:`~yadg.parsers.chromtrace`
+    is now stored as ``data`` instead of ``metadata``.
 
 Bug fixes include:
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "h5netcdf",
         "xarray-datatree>=0.0.12",
         "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git",
-        #"dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@116rc1",
+        # "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@116rc1",
     ],
     extras_require={
         "testing": ["pytest"],

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setuptools.setup(
         "requests",
         "h5netcdf",
         "xarray-datatree>=0.0.12",
-        # "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git",
-        "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@116rc1",
+        "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git",
+        #"dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@116rc1",
     ],
     extras_require={
         "testing": ["pytest"],

--- a/src/yadg/core/__init__.py
+++ b/src/yadg/core/__init__.py
@@ -153,9 +153,11 @@ def process_schema(dataschema: DataSchema, strict_merge: bool = False) -> DataTr
                     vals = xr.concat([vals, fvals], dim="uts", combine_attrs=concatmode)
                 except xr.MergeError:
                     raise RuntimeError(
-                        "Merging metadata from multiple files has failed, as the values"
-                        " differ between files. Try re-running the yadg command with "
-                        "--ignore-merge-errors."
+                        "Merging metadata from multiple files has failed, as some of the "
+                        "values differ between files. This might be caused by trying to "
+                        "parse data obtained using different techniques/protocols in a "
+                        "single step. If you are certain this is what you want, try using "
+                        "yadg with the '--ignore-merge-errors' option."
                     )
             elif isinstance(vals, DataTree):
                 for k, v in fvals.items():
@@ -168,9 +170,11 @@ def process_schema(dataschema: DataSchema, strict_merge: bool = False) -> DataTr
                             )
                         except xr.MergeError:
                             raise RuntimeError(
-                                "Merging metadata from multiple files has failed, as the values"
-                                " differ between files. Try re-running the yadg command with "
-                                "--ignore-merge-errors."
+                                "Merging metadata from multiple files has failed, as some of the "
+                                "values differ between files. This might be caused by trying to "
+                                "parse data obtained using different techniques/protocols in a "
+                                "single step. If you are certain this is what you want, try using "
+                                "yadg with the '--ignore-merge-errors' option."
                             )
                     else:
                         newv = v.ds

--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -2,6 +2,7 @@ import importlib
 import logging
 from dgbowl_schemas.yadg.dataschema import ExtractorFactory
 from pydantic import ValidationError
+from pydantic.v1 import ValidationError as ValidationError_v1
 from pathlib import Path
 from zoneinfo import ZoneInfo
 import xarray as xr
@@ -66,7 +67,7 @@ def extract(filetype: str, path: Path) -> Union[xr.Dataset, datatree.DataTree]:
         try:
             ftype = ExtractorFactory(extractor={"filetype": k}).extractor
             break
-        except ValidationError as e:
+        except (ValidationError, ValidationError_v1) as e:
             print(e)
             pass
     else:

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -92,9 +92,16 @@ def run_with_arguments():
     )
     process.add_argument(
         "--ignore-file-errors",
-        dest="permissive",
+        dest="ignore_file_errors",
         action="store_true",
         help="Ignore file opening errors while processing schemafile",
+        default=False,
+    )
+    process.add_argument(
+        "--ignore-merge-errors",
+        dest="ignore_merge_errors",
+        action="store_true",
+        help="Ignore metadata merge errors while processing multiple files in a step.",
         default=False,
     )
     process.set_defaults(func=subcommands.process)
@@ -151,6 +158,20 @@ def run_with_arguments():
             "instead. Default in that case is 'datagram.nc'."
         ),
         default=None,
+    )
+    preset.add_argument(
+        "--ignore-file-errors",
+        dest="ignore_file_errors",
+        action="store_true",
+        help="Ignore file opening errors while processing schemafile",
+        default=False,
+    )
+    preset.add_argument(
+        "--ignore-merge-errors",
+        dest="ignore_merge_errors",
+        action="store_true",
+        help="Ignore metadata merge errors while processing multiple files in a step.",
+        default=False,
     )
     preset.set_defaults(func=subcommands.preset)
 

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -91,13 +91,6 @@ def run_with_arguments():
         default="datagram.nc",
     )
     process.add_argument(
-        "--ignore-file-errors",
-        dest="ignore_file_errors",
-        action="store_true",
-        help="Ignore file opening errors while processing schemafile",
-        default=False,
-    )
-    process.add_argument(
         "--ignore-merge-errors",
         dest="ignore_merge_errors",
         action="store_true",
@@ -158,13 +151,6 @@ def run_with_arguments():
             "instead. Default in that case is 'datagram.nc'."
         ),
         default=None,
-    )
-    preset.add_argument(
-        "--ignore-file-errors",
-        dest="ignore_file_errors",
-        action="store_true",
-        help="Ignore file opening errors while processing schemafile",
-        default=False,
     )
     preset.add_argument(
         "--ignore-merge-errors",

--- a/src/yadg/parsers/chromdata/fusionjson.py
+++ b/src/yadg/parsers/chromdata/fusionjson.py
@@ -76,10 +76,6 @@ def process(
     }
     uts = str_to_uts(timestamp=jsdata["runTimeStamp"], timezone=timezone)
 
-    # valve = jsdata.get("annotations", {}).get("valcoPosition", None)
-    # if valve is not None:
-    #    metadata["valve"] = valve
-
     sampleid = jsdata.get("annotations", {}).get("name", None)
     if sampleid is not None:
         metadata["sampleid"] = sampleid
@@ -129,6 +125,10 @@ def process(
                     raw["retention time"][peak["label"]] = (float(peak["top"]), 0.01)
         else:
             logger.warning("'analysis' of chromatogram not present in file '%s'", fn)
+
+    valve = jsdata.get("annotations", {}).get("valcoPosition", None)
+    if valve is not None:
+        raw["valve"] = valve
 
     species = sorted(species)
     data_vars = {}

--- a/src/yadg/parsers/chromdata/fusionjson.py
+++ b/src/yadg/parsers/chromdata/fusionjson.py
@@ -76,9 +76,9 @@ def process(
     }
     uts = str_to_uts(timestamp=jsdata["runTimeStamp"], timezone=timezone)
 
-    valve = jsdata.get("annotations", {}).get("valcoPosition", None)
-    if valve is not None:
-        metadata["valve"] = valve
+    # valve = jsdata.get("annotations", {}).get("valcoPosition", None)
+    # if valve is not None:
+    #    metadata["valve"] = valve
 
     sampleid = jsdata.get("annotations", {}).get("name", None)
     if sampleid is not None:

--- a/src/yadg/parsers/chromdata/fusionzip.py
+++ b/src/yadg/parsers/chromdata/fusionzip.py
@@ -55,5 +55,13 @@ def process(*, fn: str, encoding: str, timezone: str, **kwargs: dict) -> xr.Data
                 if ds is None:
                     ds = ids
                 else:
-                    ds = xr.concat([ds, ids], dim="uts", combine_attrs="identical")
+                    try:
+                        ds = xr.concat([ds, ids], dim="uts", combine_attrs="identical")
+                    except xr.MergeError:
+                        raise RuntimeError(
+                            "Merging metadata from the unzipped fusion-json files has failed. "
+                            "This might be caused by trying to parse data obtained using "
+                            "different chromatographic methods. Please check the contents "
+                            "of the unzipped files."
+                        )
     return ds

--- a/src/yadg/parsers/chromtrace/agilentdx.py
+++ b/src/yadg/parsers/chromtrace/agilentdx.py
@@ -67,11 +67,17 @@ def process(*, fn: str, encoding: str, timezone: str, **kwargs: dict) -> DataTre
                 elif isinstance(dt, DataTree):
                     for k, v in fdt.items():
                         if k in dt:  # pylint: disable=E1135
-                            newv = xr.concat(
-                                [dt[k].ds, v.ds],  # pylint: disable=E1136
-                                dim="uts",
-                                combine_attrs="identical",
-                            )
+                            try:
+                                newv = xr.concat(
+                                    [dt[k].ds, v.ds],  # pylint: disable=E1136
+                                    dim="uts",
+                                    combine_attrs="identical",
+                                )
+                            except xr.MergeError:
+                                raise RuntimeError(
+                                    "Merging metadata from the unzipped agilent-ch files has failed. "
+                                    "This is a bug. Please open an issue on GitHub."
+                                )
                         else:
                             newv = v.ds
                         dt[k] = DataTree(newv)  # pylint: disable=E1137

--- a/src/yadg/parsers/chromtrace/fusionjson.py
+++ b/src/yadg/parsers/chromtrace/fusionjson.py
@@ -68,10 +68,6 @@ def process(*, fn: str, encoding: str, timezone: ZoneInfo, **kwargs: dict) -> Da
     }
     uts = str_to_uts(timestamp=jsdata["runTimeStamp"], timezone=timezone)
 
-    valve = jsdata.get("annotations", {}).get("valcoPosition", None)
-    if valve is not None:
-        metadata["valve"] = valve
-
     # sort detector keys to ensure alphabetic order for ID matching
     traces = sorted(jsdata["detectors"].keys())
     vals = {}
@@ -105,6 +101,9 @@ def process(*, fn: str, encoding: str, timezone: ZoneInfo, **kwargs: dict) -> Da
             },
             attrs={},
         )
+        valve = jsdata.get("annotations", {}).get("valcoPosition", None)
+        if valve is not None:
+            fvals["valve"] = valve
         vals[detname] = fvals
 
     dt = DataTree.from_dict(vals)

--- a/src/yadg/parsers/flowdata/drycal.py
+++ b/src/yadg/parsers/flowdata/drycal.py
@@ -14,19 +14,19 @@ parsed from the prefix of the filename.
 from striprtf.striprtf import rtf_to_text
 from ..basiccsv.main import process_row, append_dicts, dicts_to_dataset
 from ... import dgutils
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 from typing import Optional
 from datatree import DataTree
 from zoneinfo import ZoneInfo
 
 
 class TimeDate(BaseModel):
-    class TimestampSpec(BaseModel, extra=Extra.forbid):
-        index: Optional[int]
-        format: Optional[str]
+    class TimestampSpec(BaseModel, extra="forbid"):
+        index: Optional[int] = None
+        format: Optional[str] = None
 
-    date: Optional[TimestampSpec]
-    time: Optional[TimestampSpec]
+    date: Optional[TimestampSpec] = None
+    time: Optional[TimestampSpec] = None
 
 
 def rtf(

--- a/src/yadg/parsers/masstrace/quadstarsac.py
+++ b/src/yadg/parsers/masstrace/quadstarsac.py
@@ -287,9 +287,15 @@ def process(
             if f"{ti}" not in traces:
                 traces[f"{ti}"] = ds
             else:
-                traces[f"{ti}"] = xr.concat(
-                    [traces[f"{ti}"], ds], dim="uts", combine_attrs="identical"
-                )
+                try:
+                    traces[f"{ti}"] = xr.concat(
+                        [traces[f"{ti}"], ds], dim="uts", combine_attrs="identical"
+                    )
+                except xr.MergeError:
+                    raise RuntimeError(
+                        "Merging metadata from the individual traces has failed. "
+                        "This is a bug. Please open an issue on GitHub."
+                    )
 
     ret = DataTree.from_dict(traces)
     ret.attrs = meta

--- a/src/yadg/subcommands.py
+++ b/src/yadg/subcommands.py
@@ -69,7 +69,7 @@ def process(args: argparse.Namespace) -> None:
         ds = ds.update()
 
     logger.debug("Processing schema")
-    datagram = core.process_schema(ds)
+    datagram = core.process_schema(ds, strict_merge=not args.ignore_merge_errors)
 
     logger.info("Saving datagram to '%s'.", args.outfile)
     datagram.to_netcdf(args.outfile, engine="h5netcdf")
@@ -149,7 +149,7 @@ def preset(args: argparse.Namespace) -> None:
 
     if args.process:
         logger.info("Processing created schema.")
-        datagram = core.process_schema(ds)
+        datagram = core.process_schema(ds, strict_merge=not args.ignore_merge_errors)
         args.outfile = "datagram.nc" if args.outfile is None else args.outfile
         if args.archive:
             zipfile = args.outfile.replace(".nc", "")

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -5,6 +5,7 @@ import datatree
 import yadg.core
 from dgbowl_schemas.yadg import to_dataschema, DataSchema_4_0, DataSchema_4_1
 from pydantic import ValidationError
+from pydantic.v1 import ValidationError as ValidationError_v1
 
 from .schemas import ts0, ts1, ts2, ts3, ts4, ts5
 from .schemas import fts0, fts1, fts2, fts3, fts4, fts5, fts6, fts7, fts8
@@ -84,7 +85,7 @@ def test_datagram_from_schema_file(inp_fn, ts, datadir):
 )
 def test_schema_validator_4_0(inp_dict, expr, datadir):
     os.chdir(datadir)
-    with pytest.raises(ValidationError, match=expr):
+    with pytest.raises((ValidationError, ValidationError_v1), match=expr):
         assert DataSchema_4_0(**inp_dict)
 
 
@@ -99,7 +100,7 @@ def test_schema_validator_4_0(inp_dict, expr, datadir):
 )
 def test_schema_validator_4_1(inp_dict, expr, datadir):
     os.chdir(datadir)
-    with pytest.raises(ValidationError, match=expr):
+    with pytest.raises((ValidationError, ValidationError_v1), match=expr):
         assert DataSchema_4_1(**inp_dict)
 
 


### PR DESCRIPTION
Closes #114 by:

- introduces a `--ignore-merge-errors` argument for `yadg preset` and `yadg process`, which relaxes the `identical` requirement for metadata to `drop_conflicts`.
- adds several error messages into `try - except` clauses around most `xr.concats` where merge issues could happen.