### PR TITLE
`Extract`: Implement `--meta-only` argument

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,4 +85,5 @@ autodoc_pydantic_model_show_field_summary = False
 autodoc_pydantic_model_member_order = "bysource"
 intersphinx_mapping = {
     "dgbowl_schemas": ("https://dgbowl.github.io/dgbowl-schemas/master", None),
+    "xarray": ("https://docs.xarray.dev/en/stable", None),
 }

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -10,7 +10,7 @@ Units
 **yadg** relies on the |pint|_ package for storing units in the created `datagrams`. For this, an extended :class:`pint.UnitRegistry` is exposed in **yadg**, containing definitions of some quantities present in the raw data files in addition to |pint|'s standard unit registry. This :class:`pint.UnitRegistry` should be used in downstream packages
 which depend on **yadg**.
 
-In the resulting |NetCDF| files, the unit annotations are stored in ``.attrs["units"]`` on each :class:`xr.DataArray`, that is within each "column" of each "node" of the :class:`datatree.DataTree`. If an entry does not contain ``.attrs["units"]``, the quantity is dimensionless. See :mod:`yadg.dgutils.pintutils` for more info.
+In the resulting |NetCDF| files, the unit annotations are stored in ``.attrs["units"]`` on each :class:`xarray.DataArray`, that is within each "column" of each "node" of the :class:`datatree.DataTree`. If an entry does not contain ``.attrs["units"]``, the quantity is dimensionless. See :mod:`yadg.dgutils.pintutils` for more info.
 
 Uncertainties
 +++++++++++++

--- a/docs/source/object.datagram.rst
+++ b/docs/source/object.datagram.rst
@@ -21,7 +21,7 @@ Additionally, the `datagram` is annotated by relevant metadata, including:
 
 As of ``yadg-5.0``, the `datagram` is exported as a ``NetCDF`` file. In memory, it is
 represented by a :class:`datatree.DataTree`, with individual `steps` as nodes of that
-:class:`datatree.Datatree` containing a :class:`xr.Dataset`.
+:class:`datatree.Datatree` containing a :class:`xarray.Dataset`.
 
 The top level :class:`datatree.DataTree` contains the following metadata stored in its
 attributes:
@@ -32,7 +32,7 @@ attributes:
     - the `datagram` creation timestamp formatted according to ISO8601.
 
 The contents of the attribute fields for each `step` will vary depending on the parser
-used to create the corresponding :class:`xr.Dataset`. The following conventions are used:
+used to create the corresponding :class:`xarray.Dataset`. The following conventions are used:
 
     - a `coord` field ``uts`` contains a Unix timestamp (:class:`float`),
     - uncertainties for entries are stored using separate entries with names composed as

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -39,6 +39,16 @@ The ``infile`` will be then parsed using **yadg** and, if successful, saved as a
 
 The resulting NetCDF files will contain annotation of provenance (i.e. ``yadg extract``), `filetype` information, and the resolved defaults of `timezone`, `locale`, and `encoding` used to create the NetCDF file.
 
+Metadata-only extraction
+````````````````````````
+To use **yadg** to extract and retrieve just the metadata contained in the input file, pass the ``-m / --meta-only`` argument:
+
+.. code-block:: bash
+
+    yadg extract -m filetype infile
+
+The metadata are returned as a ``.json`` file, and are generated using the :func:`~xarray.Dataset.to_dict` function of :class:`xarray.Dataset`. They contain a description of the data coordinates (``coords``), dimensions (``dims``), and variables (``data_vars``), and include their names, attributes, dtypes, and shapes.
+
 The list of supported `filetypes` that can be extracted using **yadg** can be found in the left sidebar.
 
 `Parser` mode

--- a/docs/source/version.5_0.rst
+++ b/docs/source/version.5_0.rst
@@ -20,6 +20,8 @@ New features since ``yadg-4.2`` are:
     :class:`datatree.DataTree` module.
   - Automatic update of read `dataschemas` from version ``DataSchema-4.0`` and above,
     yielding the latest verison of `dataschema` prior to parsing.
+  - Added ``yadg extract`` usage, with optional ``--meta-only`` switch, for a quick data
+    or meta data extraction from individual files.
 
 Backwards-incompatible changes include:
 

--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -38,7 +38,7 @@ def extract(filetype: str, path: Path) -> Union[xr.Dataset, datatree.DataTree]:
     Worker function of the ``extract`` subcommand.
 
     Extracts data from provided ``path``, assuming it is the specified ``filetype``. The
-    data is either returned as a :class:`datatree.DataTree` or a :class:`xr.Dataset`,
+    data is either returned as a :class:`datatree.DataTree` or a :class:`xarray.Dataset`,
     however in either case the returned objects have a :func:`ret.to_netcdf()` as well
     as a :func:`ret.to_dict()` method, which can be used to write the file.
 

--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -68,7 +68,7 @@ def extract(filetype: str, path: Path) -> Union[xr.Dataset, datatree.DataTree]:
             ftype = ExtractorFactory(extractor={"filetype": k}).extractor
             break
         except (ValidationError, ValidationError_v1) as e:
-            #print(e)
+            logging.debug(e)
             pass
     else:
         raise RuntimeError(f"Filetype '{filetype}' could not be understood.")

--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -68,7 +68,7 @@ def extract(filetype: str, path: Path) -> Union[xr.Dataset, datatree.DataTree]:
             ftype = ExtractorFactory(extractor={"filetype": k}).extractor
             break
         except (ValidationError, ValidationError_v1) as e:
-            print(e)
+            #print(e)
             pass
     else:
         raise RuntimeError(f"Filetype '{filetype}' could not be understood.")

--- a/src/yadg/main.py
+++ b/src/yadg/main.py
@@ -176,6 +176,13 @@ def run_with_arguments():
         help=("Optionally specify the output file name."),
         default=None,
     )
+    extract.add_argument(
+        "--meta-only",
+        "-m",
+        action="store_true",
+        help="Extract and return file metadata only in a JSON format.",
+        default=False,
+    )
     extract.set_defaults(func=subcommands.extract)
 
     # parse subparser args

--- a/src/yadg/parsers/basiccsv/__init__.py
+++ b/src/yadg/parsers/basiccsv/__init__.py
@@ -28,7 +28,7 @@ Schema
 ``````
 The primary functionality of :mod:`~yadg.parsers.basiccsv` is to load the tabular
 data, and determine the Unix timestamp. The headers of the tabular data are taken
-`verbatim` from the file, and appear as ``data_vars`` of the :class:`xr.Dataset`.
+`verbatim` from the file, and appear as ``data_vars`` of the :class:`xarray.Dataset`.
 The single ``coord`` for the ``data_vars`` is the deduced Unix timestamp, ``uts``.
 
 .. code-block:: yaml

--- a/src/yadg/parsers/basiccsv/main.py
+++ b/src/yadg/parsers/basiccsv/main.py
@@ -161,7 +161,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         No metadata is returned by the :mod:`~yadg.parsers.basiccsv` parser. The full
         date might not be returned, eg. when only time is specified in columns.
 

--- a/src/yadg/parsers/chromdata/__init__.py
+++ b/src/yadg/parsers/chromdata/__init__.py
@@ -34,7 +34,7 @@ The ``filetypes`` currently supported by the parser are:
 
 Schema
 ``````
-Each file is processed into a single :class:`xr.Dataset`, containing the following
+Each file is processed into a single :class:`xarray.Dataset`, containing the following
 ``coords`` and ``data_vars`` (if present in the file):
 
 .. code-block:: yaml
@@ -77,7 +77,7 @@ def process(*, filetype: str, **kwargs: dict) -> xr.Dataset:
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
     if filetype == "fusion.json":

--- a/src/yadg/parsers/chromdata/empalccsv.py
+++ b/src/yadg/parsers/chromdata/empalccsv.py
@@ -36,7 +36,7 @@ def process(*, fn: str, encoding: str, **kwargs: dict) -> xr.Dataset:
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
 

--- a/src/yadg/parsers/chromdata/empalcxlsx.py
+++ b/src/yadg/parsers/chromdata/empalcxlsx.py
@@ -35,7 +35,7 @@ def process(*, fn: str, **kwargs: dict) -> xr.Dataset:
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
     try:

--- a/src/yadg/parsers/chromdata/fusioncsv.py
+++ b/src/yadg/parsers/chromdata/fusioncsv.py
@@ -58,7 +58,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
 

--- a/src/yadg/parsers/chromdata/fusionjson.py
+++ b/src/yadg/parsers/chromdata/fusionjson.py
@@ -63,7 +63,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
 

--- a/src/yadg/parsers/chromdata/fusionzip.py
+++ b/src/yadg/parsers/chromdata/fusionzip.py
@@ -37,9 +37,9 @@ def process(*, fn: str, encoding: str, timezone: str, **kwargs: dict) -> xr.Data
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         The data from the inidividual json files contained in the zip archive are
-        concatenated into a single :class:`xr.Dataset`. This might fail if the metadata
+        concatenated into a single :class:`xarray.Dataset`. This might fail if the metadata
         in the json files differs, or if the dimensions are not easily concatenable.
 
     """

--- a/src/yadg/parsers/chromtrace/__init__.py
+++ b/src/yadg/parsers/chromtrace/__init__.py
@@ -41,7 +41,7 @@ The ``filetypes`` currently supported by the parser are:
 
 Schema
 ``````
-The data is returned as a :class:`datatree.Datatree`, containing a :class:`xr.Dataset`
+The data is returned as a :class:`datatree.Datatree`, containing a :class:`xarray.Dataset`
 for each trace / detector name:
 
 .. code-block:: yaml

--- a/src/yadg/parsers/chromtrace/agilentch.py
+++ b/src/yadg/parsers/chromtrace/agilentch.py
@@ -82,7 +82,7 @@ def process(*, fn: str, timezone: ZoneInfo, **kwargs: dict) -> DataTree:
     Returns
     -------
     class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per detector. As
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per detector. As
         there is only one detector data in each CH file, this nesting is only for
         consistency with other filetypes.
 

--- a/src/yadg/parsers/chromtrace/agilentcsv.py
+++ b/src/yadg/parsers/chromtrace/agilentcsv.py
@@ -83,7 +83,7 @@ def process(*, fn: str, encoding: str, timezone: str, **kwargs: dict) -> DataTre
     Returns
     -------
     class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per detector. As
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per detector. As
         When multiple timesteps are present in the file, the traces of each detector are
         expanded to match the longest trace, and collated along the ``uts``-dimension.
     """

--- a/src/yadg/parsers/chromtrace/agilentdx.py
+++ b/src/yadg/parsers/chromtrace/agilentdx.py
@@ -48,7 +48,7 @@ def process(*, fn: str, encoding: str, timezone: str, **kwargs: dict) -> DataTre
     Returns
     -------
     class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per detector. If
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per detector. If
         multiple timesteps are found in the zip archive, the :class:`datatree.DataTrees`
         are collated along the ``uts`` dimension.
 

--- a/src/yadg/parsers/chromtrace/ezchromasc.py
+++ b/src/yadg/parsers/chromtrace/ezchromasc.py
@@ -44,7 +44,7 @@ def process(*, fn: str, encoding: str, timezone: ZoneInfo, **kwargs: dict) -> Da
     Returns
     -------
     class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per detector.
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per detector.
 
     """
 

--- a/src/yadg/parsers/chromtrace/fusionjson.py
+++ b/src/yadg/parsers/chromtrace/fusionjson.py
@@ -54,7 +54,7 @@ def process(*, fn: str, encoding: str, timezone: ZoneInfo, **kwargs: dict) -> Da
     Returns
     -------
     class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per detector.
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per detector.
 
     """
 

--- a/src/yadg/parsers/chromtrace/fusionzip.py
+++ b/src/yadg/parsers/chromtrace/fusionzip.py
@@ -49,7 +49,7 @@ def process(*, fn: str, encoding: str, timezone: str, **kwargs: dict) -> DataTre
     Returns
     -------
     class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per detector. If
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per detector. If
         multiple timesteps are found in the zip archive, the :class:`datatree.DataTrees`
         are collated along the ``uts`` dimension.
 

--- a/src/yadg/parsers/dummy/__init__.py
+++ b/src/yadg/parsers/dummy/__init__.py
@@ -70,7 +70,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
     if filetype == "tomato.json":

--- a/src/yadg/parsers/electrochem/__init__.py
+++ b/src/yadg/parsers/electrochem/__init__.py
@@ -30,7 +30,7 @@ The ``filetypes`` currently supported by the parser are:
 
 Schema
 ``````
-Depending on the filetype, the output :class:`xr.Dataset` may contain multiple
+Depending on the filetype, the output :class:`xarray.Dataset` may contain multiple
 derived values. However, all filetypes will report at least the following:
 
 .. code-block:: yaml
@@ -76,7 +76,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
     if filetype == "eclab.mpr":

--- a/src/yadg/parsers/electrochem/eclabmpr.py
+++ b/src/yadg/parsers/electrochem/eclabmpr.py
@@ -666,7 +666,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         The full date is specified only if the "LOG" module is present.
 
     """

--- a/src/yadg/parsers/electrochem/eclabmpt.py
+++ b/src/yadg/parsers/electrochem/eclabmpt.py
@@ -221,7 +221,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         The full date may not be specified if header is not present.
 
     """

--- a/src/yadg/parsers/flowdata/main.py
+++ b/src/yadg/parsers/flowdata/main.py
@@ -35,7 +35,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
     """
 

--- a/src/yadg/parsers/masstrace/__init__.py
+++ b/src/yadg/parsers/masstrace/__init__.py
@@ -2,7 +2,7 @@
 Handles the reading and processing of mass spectrometry files. The basic function of the
 parser is to:
 
-#. read in the raw data and create timestamped traces with one :class:`xr.Dataset` per trace
+#. read in the raw data and create timestamped traces with one :class:`xarray.Dataset` per trace
 #. collect `metadata` such as the software version, author, etc.
 
 Usage

--- a/src/yadg/parsers/masstrace/quadstarsac.py
+++ b/src/yadg/parsers/masstrace/quadstarsac.py
@@ -182,9 +182,9 @@ def process(
     Returns
     -------
     :class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing one :class:`xr.Dataset` per mass trace.
+        A :class:`datatree.DataTree` containing one :class:`xarray.Dataset` per mass trace.
         The traces in the Quadstar ``.sac`` files are not named, therefore their index
-        is used as the :class:`xr.Dataset` name.
+        is used as the :class:`xarray.Dataset` name.
 
     """
     with open(fn, "rb") as sac_file:

--- a/src/yadg/parsers/meascsv/__init__.py
+++ b/src/yadg/parsers/meascsv/__init__.py
@@ -71,8 +71,8 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
-        A :class:`xr.Dataset` containing the timesteps, metadata, and full date tag. No
+    :class:`xarray.Dataset`
+        A :class:`xarray.Dataset` containing the timesteps, metadata, and full date tag. No
         metadata is returned. The full date is always provided in :mod:`~yadg.parsers.meascsv`
         compatible files.
 

--- a/src/yadg/parsers/qftrace/labviewcsv.py
+++ b/src/yadg/parsers/qftrace/labviewcsv.py
@@ -39,7 +39,7 @@ def process(
     Returns
     -------
     :class:`datatree.DataTree`
-        A :class:`datatree.DataTree` containing a single :class:`xr.Dataset` with the
+        A :class:`datatree.DataTree` containing a single :class:`xarray.Dataset` with the
         ``S11`` (reflection) trace.
 
     """

--- a/src/yadg/parsers/xpstrace/phispe.py
+++ b/src/yadg/parsers/xpstrace/phispe.py
@@ -416,7 +416,7 @@ def process(
     Returns
     -------
     :class:`datatree.DataTree`
-        Returns a :class:`datatree.DataTree` containing a :class:`xr.Dataset` for each
+        Returns a :class:`datatree.DataTree` containing a :class:`xarray.Dataset` for each
         XPS trace present in the input file.
 
     """

--- a/src/yadg/parsers/xrdtrace/__init__.py
+++ b/src/yadg/parsers/xrdtrace/__init__.py
@@ -62,7 +62,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
 
 
     """

--- a/src/yadg/parsers/xrdtrace/panalyticalcsv.py
+++ b/src/yadg/parsers/xrdtrace/panalyticalcsv.py
@@ -114,7 +114,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         Data containing the timesteps and metadata. This filetype contains the full
         date specification.
 

--- a/src/yadg/parsers/xrdtrace/panalyticalxrdml.py
+++ b/src/yadg/parsers/xrdtrace/panalyticalxrdml.py
@@ -205,7 +205,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         Data containing the timesteps, and metadata. This filetype contains the full
         date specification.
 

--- a/src/yadg/parsers/xrdtrace/panalyticalxy.py
+++ b/src/yadg/parsers/xrdtrace/panalyticalxy.py
@@ -44,7 +44,7 @@ def process(
 
     Returns
     -------
-    :class:`xr.Dataset`
+    :class:`xarray.Dataset`
         Tuple containing the timesteps and metadata. A full timestamp is not available
         in ``.xy`` files.
 

--- a/src/yadg/subcommands.py
+++ b/src/yadg/subcommands.py
@@ -193,9 +193,13 @@ def extract(args: argparse.Namespace) -> None:
     )
 
     if args.outfile is None:
-        outpath = path.with_suffix(".nc")
+        outpath = path.with_suffix(".json" if args.meta_only else ".nc")
     else:
         outpath = Path(args.outfile)
 
     ret = extractors.extract(args.filetype, path)
-    ret.to_netcdf(outpath, engine="h5netcdf")
+    if args.meta_only:
+        with outpath.open("w", encoding="UTF-8") as target:
+            json.dump(ret.to_dict(data = False), target)
+    else:
+        ret.to_netcdf(outpath, engine="h5netcdf")

--- a/src/yadg/subcommands.py
+++ b/src/yadg/subcommands.py
@@ -200,6 +200,6 @@ def extract(args: argparse.Namespace) -> None:
     ret = extractors.extract(args.filetype, path)
     if args.meta_only:
         with outpath.open("w", encoding="UTF-8") as target:
-            json.dump(ret.to_dict(data = False), target)
+            json.dump(ret.to_dict(data=False), target)
     else:
         ret.to_netcdf(outpath, engine="h5netcdf")

--- a/tests/test_yadg.py
+++ b/tests/test_yadg.py
@@ -178,6 +178,24 @@ def test_yadg_extract(filetype, infile, datadir):
     compare_datatrees(ret, ref)
 
 
+@pytest.mark.parametrize(
+    "filetype, infile, flag",
+    [
+        ("eclab.mpr", "cp.mpr", "-m"),
+        ("marda:biologic-mpr", "cp.mpr", "--meta-only"),
+        ("biologic-mpr", "cp.mpr", "-m"),
+    ],
+)
+def test_yadg_extract_meta_only(filetype, infile, flag, datadir):
+    os.chdir(datadir)
+    command = ["yadg", "extract", filetype, infile, flag]
+    subprocess.run(command, check=True)
+    assert os.path.exists("cp.json")
+    # ret = open_datatree("test.nc")
+    # ref = open_datatree(f"ref.{infile}.nc")
+    # compare_datatrees(ret, ref)
+
+
 def test_yadg_preset_dataschema_compat(datadir):
     os.chdir(datadir)
     sfns = [fn for fn in os.listdir() if fn.endswith("yml") and fn.startswith("ds")]

--- a/tests/test_yadg.py
+++ b/tests/test_yadg.py
@@ -1,6 +1,7 @@
 import pytest
 import subprocess
 import os
+import json
 from datatree import open_datatree
 
 from .utils import pars_datagram_test, standard_datagram_test, compare_datatrees
@@ -191,9 +192,10 @@ def test_yadg_extract_meta_only(filetype, infile, flag, datadir):
     command = ["yadg", "extract", filetype, infile, flag]
     subprocess.run(command, check=True)
     assert os.path.exists("cp.json")
-    # ret = open_datatree("test.nc")
-    # ref = open_datatree(f"ref.{infile}.nc")
-    # compare_datatrees(ret, ref)
+    with open("cp.json", "r") as inp:
+        ret = json.load(inp)
+    for key in {"attrs", "coords", "dims", "data_vars"}:
+        assert key in ret.keys()
 
 
 def test_yadg_preset_dataschema_compat(datadir):


### PR DESCRIPTION
- implements and documents `--meta-only` argument to `yadg extract`
- adds a very basic test
- updates docs