### PR TITLE
Better handling of locales

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,4 +85,5 @@ intersphinx_mapping = {
     "dgbowl_schemas": ("https://dgbowl.github.io/dgbowl-schemas/master", None),
     "xarray": ("https://docs.xarray.dev/en/stable", None),
     "datatree": ("https://xarray-datatree.readthedocs.io/en/latest/", None),
+    "babel": ("https://babel.pocoo.org/en/latest/", None),
 }

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -30,6 +30,11 @@ Another key feature in **yadg** is the timestamping of all datapoints. The Unix 
 Most of the supported file formats contain a timestamp of some kind. However, several file formats may not define both date and time of each datapoint, or may define neither. That is why **yadg** includes a powerful "external date" interface, see :func:`~yadg.dgutils.dateutils.complete_timestamps`.
 
 
+Locale support
+``````````````
+Support for parsing numbers in localized files is implemented in **yadg** via the :mod:`babel` library, allowing the users to specify the locale of the file using standard locale strings, such as ``en_US`` or ``de_CH``. This avoids "hacks" such as replacing decimal separators (``,`` vs ``.``) and thousands separators when processing localizable files. By default, **yadg** attempts to infer the locale from the ``LC_NUMERIC`` environment variable; if this is not set in your environment, ``en_GB`` is used as a fallback.
+
+
 `Dataschema` validation
 ```````````````````````
 Additionally, **yadg** provides `dataschema` validation functionality, by using the schema models from the :mod:`dgbowl_schemas.yadg.dataschema` package, implemented in |Pydantic|_. The schemas are developed in lockstep with **yadg**. This |Pydantic|-based validator class should be used to ensure that the incoming `dataschema` is valid.

--- a/docs/source/version.5_1.rst
+++ b/docs/source/version.5_1.rst
@@ -25,6 +25,7 @@ Other changes in ``yadg-5.1`` are:
 
   - The dataschema has been simplified, eliminating parsers in favour of extractors.
   - The code has been reorganised to highlight the extractor functionality in favour of parsers.
+  - Locale-aware functionality now uses :mod:`babel` instead of the built-in :mod:`locale` module. This means the ``locale`` argument should now be a :class:`str` containing at least the 2-letter country code, ideally also a territory (e.g. ``en_US`` or ``de_CH``). As of ``yadg-5.1``, no :func:`locale.setlocale` is called, making locale procesing in **yadg** thread-safe.
 
 Bug fixes in ``yadg-5.1`` include:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "olefile >= 0.47",
     "h5netcdf ~= 1.0",
     "pandas >= 2.0",
+    "babel >= 2.15",
     "xarray-datatree ~= 0.0.12",
     "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@dataschema_5.1",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "h5netcdf ~= 1.0",
     "pandas >= 2.0",
     "babel >= 2.15",
-    "xarray-datatree ~= 0.0.12",
+    "xarray-datatree >= 0.0.12",
     "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@dataschema_5.1",
     "requests",
 ]

--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -11,7 +11,13 @@ from dgbowl_schemas.yadg.dataschema import ExtractorFactory
 logger = logging.getLogger(__name__)
 
 
-def extract(filetype: str, path: Path) -> Union[Dataset, DataTree]:
+def extract(
+    filetype: str,
+    path: Path,
+    timezone: str = None,
+    encoding: str = None,
+    locale: str = None,
+) -> Union[Dataset, DataTree]:
     """
     The individual extractor functionality of yadg is called from here.
 
@@ -30,7 +36,14 @@ def extract(filetype: str, path: Path) -> Union[Dataset, DataTree]:
         A :class:`pathlib.Path` object pointing to the file to be extracted.
 
     """
-    extractor = ExtractorFactory(extractor={"filetype": filetype}).extractor
+    extractor = ExtractorFactory(
+        extractor={
+            "filetype": filetype,
+            "timezone": timezone,
+            "encoding": encoding,
+            "locale": locale,
+        }
+    ).extractor
 
     m = importlib.import_module(f"yadg.extractors.{extractor.filetype}")
     func = getattr(m, "extract")

--- a/src/yadg/extractors/basic/csv.py
+++ b/src/yadg/extractors/basic/csv.py
@@ -44,6 +44,7 @@ No metadata is extracted.
 
 import logging
 from pydantic import BaseModel
+from babel.numbers import parse_decimal
 import locale as lc
 from xarray import Dataset
 from uncertainties.core import str_to_number_with_uncert as tuple_fromstr
@@ -52,7 +53,7 @@ from typing import Callable
 
 from yadg import dgutils
 
-
+default_locale = lc.getlocale(lc.LC_NUMERIC)[0]
 logger = logging.getLogger(__name__)
 
 
@@ -61,6 +62,7 @@ def process_row(
     items: list,
     datefunc: Callable,
     datecolumns: list[int],
+    locale: str = default_locale,
 ) -> tuple[dict, dict]:
     """
     A function that processes a row of a table.
@@ -107,7 +109,7 @@ def process_row(
         elif columns[ci] == "":
             continue
         try:
-            val, dev = tuple_fromstr(lc.delocalize(columns[ci]))
+            val, dev = tuple_fromstr(str(parse_decimal(columns[ci], locale=locale)))
             vals[header] = val
             devs[header] = dev
         except ValueError:
@@ -162,8 +164,6 @@ def extract(
     units = dgutils.sanitize_units(units)
 
     # Process rows
-    old_loc = lc.getlocale(category=lc.LC_NUMERIC)
-    lc.setlocale(lc.LC_NUMERIC, locale=locale)
     data_vals = {}
     meta_vals = {"_fn": []}
     for li, line in enumerate(lines[si:]):
@@ -172,8 +172,8 @@ def extract(
             [i.strip().strip(strip) for i in line.split(parameters.sep)],
             datefunc,
             datecolumns,
+            locale=locale,
         )
         dgutils.append_dicts(vals, devs, data_vals, meta_vals, fn, li)
-    lc.setlocale(category=lc.LC_NUMERIC, locale=old_loc)
 
     return dgutils.dicts_to_dataset(data_vals, meta_vals, units, fulldate)

--- a/src/yadg/extractors/basic/csv.py
+++ b/src/yadg/extractors/basic/csv.py
@@ -45,7 +45,6 @@ No metadata is extracted.
 import logging
 from pydantic import BaseModel
 from babel.numbers import parse_decimal
-import locale as lc
 from xarray import Dataset
 from uncertainties.core import str_to_number_with_uncert as tuple_fromstr
 from typing import Callable
@@ -53,7 +52,7 @@ from typing import Callable
 
 from yadg import dgutils
 
-default_locale = lc.getlocale(lc.LC_NUMERIC)[0]
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +61,7 @@ def process_row(
     items: list,
     datefunc: Callable,
     datecolumns: list[int],
-    locale: str = default_locale,
+    locale: str = "en_GB",
 ) -> tuple[dict, dict]:
     """
     A function that processes a row of a table.


### PR DESCRIPTION
This will fix some of the issues in #151.

- allows passing `timezone`, `encoding`, `locale` into `yadg.extractors.extract()`
- use `babel`'s `parse_decimal()` instead of `locale`'s `atof()` to localize numbers
- `locale` should now always be a string that can be understood by `babel.Locale.parse()` - i.e. `en_GB` or `de_DE`
- `locale` default is now pulled from `locale.LC_NUMERIC` and falls back to `en_GB` when unset