### PR TITLE
mpr file fixes

### DIFF
--- a/src/yadg/extractors/eclab/common/techniques.py
+++ b/src/yadg/extractors/eclab/common/techniques.py
@@ -609,6 +609,7 @@ technique_params_dtypes = {
     0x1E: ("GEIS", _geis_params_dtype),
     0x32: ("ZIR", _zir_params_dtypes),
     0x6C: ("LSV", _lsv_params_dtype),
+    0x77: ("GCPL", _gcpl_params_dtypes),
     0x7F: ("MB", _mb_params_dtypes),
 }
 
@@ -793,7 +794,7 @@ def param_from_key(
                     return i[0]
                 else:
                     return i[2]
-        raise ValueError(f"element '{key}' for parameter '{param}' not understood.")
+        logger.warning(f"element '{key}' for parameter '{param}' not understood.")
     return key
 
 

--- a/src/yadg/extractors/eclab/mpr.py
+++ b/src/yadg/extractors/eclab/mpr.py
@@ -273,6 +273,14 @@ def process_settings(data: bytes) -> tuple[dict, list]:
                 params_dtype, params_offset = dtype, offset
                 logger.debug("Determined %d parameters at 0x%x.", n_params, offset)
                 break
+            # Manually merged/appended mpr files have a mysterious additional parameter
+            if len(dtype) == n_params - 1:
+                tmp_descr = dtype.descr
+                tmp_descr.append(("unknown", "<f4"))
+                new_dtype = np.dtype(tmp_descr)
+                params_dtype, params_offset = new_dtype, offset
+                logger.debug("Determined %d parameters at 0x%x.", n_params, offset)
+                break
         if params_offset is not None:
             break
     if params_offset is None:


### PR DESCRIPTION
Changes to process certain BioLogic mpr files that could not be processed before. To fix the issues below, 

- Added an alternative technique param dtype for GCPL (0x77). 
- The function param_from_key used to raise  a ValueError if a single key was not understood. This is a drastic measure that interupts extraction of all successfully extracted parameters if one parameter is added. Replaced the error with a warning.
- Appending/merging multiple cycling files in eclab added an additional parameter to the settings, which caused the process to fail.