### PR TITLE
`eclab`: Improve extractor performance.

### DIFF
--- a/src/yadg/extractors/eclab/common/techniques.py
+++ b/src/yadg/extractors/eclab/common/techniques.py
@@ -839,9 +839,7 @@ def param_from_key(
     return key
 
 
-def get_dev_VI(
-    name: str, value: float, unit: str, Erange: float, Irange: float
-) -> float:
+def dev_VI(name: str, value: float, unit: str, Erange: float, Irange: float) -> float:
     """
     Function that returns the resolution of a voltage or current based on its name,
     value, E-range and I-range.
@@ -871,7 +869,7 @@ def get_dev_VI(
         raise RuntimeError(f"Unknown quantity {name!r} passed with unit {unit!r}.")
 
 
-def get_dev_derived(
+def dev_derived(
     name: str,
     unit: str,
     val: float,
@@ -956,7 +954,7 @@ def get_devs(
         if val is None:
             continue
         devs[col] = max(
-            get_dev_VI(col, abs(val), unit, Erange, Irange),
+            dev_VI(col, abs(val), unit, Erange, Irange),
             devs.get(col, float("nan")),
         )
         if val == 0.0:
@@ -973,9 +971,12 @@ def get_devs(
             continue
         unit = units.get(col)
         if isinstance(val, float):
-            devs[col] = max(
-                get_dev_derived(col, unit, abs(val), rtol_I, rtol_V, r_sqrtVI),
-                devs.get(col, float("nan")),
-            )
+            if col in devs:
+                devs[col] = max(
+                    devs[col],
+                    dev_derived(col, unit, abs(val), rtol_I, rtol_V, r_sqrtVI),
+                )
+            else:
+                devs[col] = dev_derived(col, unit, abs(val), rtol_I, rtol_V, r_sqrtVI)
 
     return devs

--- a/src/yadg/extractors/eclab/common/techniques.py
+++ b/src/yadg/extractors/eclab/common/techniques.py
@@ -872,7 +872,12 @@ def get_dev_VI(
 
 
 def get_dev_derived(
-    name: str, unit: str, val: float, rtol_I: float, rtol_V: float, rtol_VI: float,
+    name: str,
+    unit: str,
+    val: float,
+    rtol_I: float,
+    rtol_V: float,
+    rtol_VI: float,
 ) -> float:
     """
     Function that returns the resolution of a derived quantity based on its unit,

--- a/src/yadg/extractors/eclab/mpt.py
+++ b/src/yadg/extractors/eclab/mpt.py
@@ -62,7 +62,6 @@ from typing import Any
 from babel.numbers import parse_decimal
 from datatree import DataTree
 from yadg import dgutils
-from uncertainties.core import str_to_number_with_uncert as tuple_fromstr
 from .common.techniques import get_devs, param_from_key
 from .common.mpt_columns import column_units
 
@@ -236,11 +235,10 @@ def process_data(
                     vals[name] = ival
             else:
                 try:
-                    fval, fdev = tuple_fromstr(
-                        parse_decimal(value, locale=locale).to_eng_string()
-                    )
-                    vals[name] = fval
-                    devs[name] = fdev
+                    dec = parse_decimal(value, locale=locale)
+                    vals[name] = float(dec)
+                    exp = dec.as_tuple().exponent
+                    devs[name] = float("nan") if isinstance(exp, str) else 10**exp
                 except ValueError:
                     sval = value.strip()
                     vals[name] = sval

--- a/src/yadg/extractors/eclab/mpt.py
+++ b/src/yadg/extractors/eclab/mpt.py
@@ -226,7 +226,8 @@ def process_data(
         values = line.split("\t")
         vals = dict()
         devs = dict()
-        for name, value in list(zip(columns, values)):
+        for ci, name in enumerate(columns):
+            value = values[ci]
             if units.get(name) is None:
                 ival = int(parse_decimal(value, locale=locale))
                 if name == "I Range":

--- a/tests/test_x_eclab_mpt.py
+++ b/tests/test_x_eclab_mpt.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import pickle
 import xarray as xr
+import numpy as np
 from yadg.extractors.eclab.mpt import extract
 from .utils import compare_datatrees
 
@@ -78,7 +79,8 @@ def test_eclab_mpt_old(afile, bfile, datadir):
         try:
             xr.testing.assert_allclose(aret[key], bret[key])
         except AssertionError as e:
-            if key in {"Efficiency"}:
+            if key in {"Efficiency", "Efficiency_std_err"}:
                 pass
             else:
+                e.args = (e.args[0] + f"Error happened on key: {key!r}\n",)
                 raise e

--- a/tests/test_x_eclab_mpt.py
+++ b/tests/test_x_eclab_mpt.py
@@ -2,7 +2,6 @@ import pytest
 import os
 import pickle
 import xarray as xr
-import numpy as np
 from yadg.extractors.eclab.mpt import extract
 from .utils import compare_datatrees
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,7 +41,7 @@ def compare_datatrees(
                 xr.testing.assert_allclose(ret[k], ref[k], atol=atol)
             except AssertionError as e:
                 e.args = (e.args[0] + f"Error happened on key: {k!r}\n",)
-                raise AssertionError(e.args)
+                raise AssertionError(*e.args)
             # if thislevel:
             #    check_attrs(ref.attrs, ret.attrs)
         else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,7 +41,7 @@ def compare_datatrees(
                 xr.testing.assert_allclose(ret[k], ref[k], atol=atol)
             except AssertionError as e:
                 e.args = (e.args[0] + f"Error happened on key: {k!r}\n",)
-                raise AssertionError(*e.args)
+                raise e
             # if thislevel:
             #    check_attrs(ref.attrs, ret.attrs)
         else:


### PR DESCRIPTION
Baseline: ubuntu - python 3.9 and 3.10: 4m56s
- avoid using `tuple_fromstr()`: 4m34s (-22s)
- avoid `list(zip())` every row: 4m35s (+1s)
- avoid `np.NaN` and `np.nanmax`: 3m16: (-80s)