### PR TITLE
Touches before `yadg-5.1rc1`

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -6,10 +6,10 @@ jobs:
     build:
         strategy:
             matrix:
-                pyver: ['3.9', '3.10', '3.11']
+                pyver: ['3.10', '3.11', '3.12']
                 os: ['ubuntu-latest']
                 include:
-                  - pyver: '3.9'
+                  - pyver: '3.10'
                     os: 'windows-latest'
         uses: ./.github/workflows/workflow-build.yml
         with:
@@ -19,10 +19,10 @@ jobs:
         needs: [build]
         strategy:
             matrix:
-                pyver: ['3.9', '3.10', '3.11']
+                pyver: ['3.10', '3.11', '3.12']
                 os: ['ubuntu-latest']
                 include:
-                  - pyver: '3.9'
+                  - pyver: '3.10'
                     os: 'windows-latest'
         uses: ./.github/workflows/workflow-test.yml
         with:
@@ -32,5 +32,5 @@ jobs:
         needs: [build]
         uses: ./.github/workflows/workflow-pages.yml
         with:
-            pyver: '3.9'
+            pyver: '3.10'
             os: ubuntu-latest

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -6,10 +6,10 @@ jobs:
     build:
         strategy:
             matrix:
-                pyver: ['3.10', '3.11', '3.12']
+                pyver: ['3.9', '3.10', '3.11', '3.12']
                 os: ['ubuntu-latest']
                 include:
-                  - pyver: '3.10'
+                  - pyver: '3.9'
                     os: 'windows-latest'
         uses: ./.github/workflows/workflow-build.yml
         with:
@@ -19,10 +19,10 @@ jobs:
         needs: [build]
         strategy:
             matrix:
-                pyver: ['3.10', '3.11', '3.12']
+                pyver: ['3.9', '3.10', '3.11', '3.12']
                 os: ['ubuntu-latest']
                 include:
-                  - pyver: '3.10'
+                  - pyver: '3.9'
                     os: 'windows-latest'
         uses: ./.github/workflows/workflow-test.yml
         with:
@@ -32,5 +32,5 @@ jobs:
         needs: [build]
         uses: ./.github/workflows/workflow-pages.yml
         with:
-            pyver: '3.10'
+            pyver: '3.9'
             os: ubuntu-latest

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -6,19 +6,19 @@ jobs:
     build:
         uses: ./.github/workflows/workflow-build.yml
         with:
-            pyver: '3.9'
+            pyver: '3.10'
             os: 'ubuntu-latest'
     test:
         needs: [build]
         uses: ./.github/workflows/workflow-test.yml
         with:
-            pyver: '3.9'
+            pyver: '3.10'
             os: 'ubuntu-latest'
     pages:
         needs: [build]
         uses: ./.github/workflows/workflow-pages.yml
         with:
-            pyver: '3.9'
+            pyver: '3.10'
             os: ubuntu-latest
     deploy:
         needs: [pages]
@@ -27,10 +27,10 @@ jobs:
           - uses: actions/checkout@v4
           - uses: actions/setup-python@v5
             with:
-                python-version: '3.9'
+                python-version: '3.10'
           - uses: actions/download-artifact@v4
             with:
-                name: public-ubuntu-latest-3.9
+                name: public-ubuntu-latest-3.10
                 path: public/master
           - uses: peaceiris/actions-gh-pages@v3
             with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -6,19 +6,19 @@ jobs:
     build:
         uses: ./.github/workflows/workflow-build.yml
         with:
-            pyver: '3.10'
+            pyver: '3.9'
             os: 'ubuntu-latest'
     test:
         needs: [build]
         uses: ./.github/workflows/workflow-test.yml
         with:
-            pyver: '3.10'
+            pyver: '3.9'
             os: 'ubuntu-latest'
     pages:
         needs: [build]
         uses: ./.github/workflows/workflow-pages.yml
         with:
-            pyver: '3.10'
+            pyver: '3.9'
             os: ubuntu-latest
     deploy:
         needs: [pages]
@@ -27,10 +27,10 @@ jobs:
           - uses: actions/checkout@v4
           - uses: actions/setup-python@v5
             with:
-                python-version: '3.10'
+                python-version: '3.9'
           - uses: actions/download-artifact@v4
             with:
-                name: public-ubuntu-latest-3.10
+                name: public-ubuntu-latest-3.9
                 path: public/master
           - uses: peaceiris/actions-gh-pages@v3
             with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,10 @@ classifiers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-    "numpy >= 1.20",
-    "pint >= 0.24",
+    "numpy >= 1.20; python_version > '3.9'",
+    "pint >= 0.24; python_version > '3.9'",
+    "numpy >= 1.20, < 2.0; python_version == '3.9'",
+    "pint >= 0.22; python_version == '3.9'",
     "pyyaml",
     "uncertainties",
     "striprtf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
 requires-python = ">= 3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-    "numpy >= 1.20, < 2.0",
+    "numpy >= 1.20",
     "pint >= 0.22",
     "pyyaml",
     "uncertainties",
@@ -38,7 +38,7 @@ dependencies = [
     "pandas >= 2.0",
     "babel >= 2.15",
     "xarray-datatree >= 0.0.12",
-    "dgbowl-schemas @ git+https://github.com/dgbowl/dgbowl-schemas.git@dataschema_5.1",
+    "dgbowl-schemas >= 117",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">= 3.9"
 dependencies = [
     "numpy >= 1.20",
-    "pint >= 0.22",
+    "pint >= 0.24",
     "pyyaml",
     "uncertainties",
     "striprtf",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from distutils import dir_util
+import shutil
 import os
 import pytest
 
@@ -14,5 +14,5 @@ def datadir(tmpdir, request):
     filename = request.module.__file__
     test_dir, _ = os.path.splitext(filename)
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
+        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
     return tmpdir

--- a/tests/test_x_eclab.py
+++ b/tests/test_x_eclab.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import xarray as xr
-from distutils import dir_util
+import shutil
 from yadg.extractors.eclab.mpr import extract as extract_mpr
 from yadg.extractors.eclab.mpt import extract as extract_mpt
 
@@ -12,7 +12,7 @@ def _datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
     base_dir, _ = os.path.split(test_dir)
     for ddir in ["test_x_eclab_mpr", "test_x_eclab_mpt"]:
-        dir_util.copy_tree(os.path.join(base_dir, ddir), str(tmpdir))
+        shutil.copytree(os.path.join(base_dir, ddir), str(tmpdir), dirs_exist_ok=True)
     return tmpdir
 
 

--- a/tests/test_x_empalc.py
+++ b/tests/test_x_empalc.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from distutils import dir_util
+import shutil
 from yadg.extractors.empalc.xlsx import extract as extract_xls
 from yadg.extractors.empalc.csv import extract as extract_csv
 import xarray as xr
@@ -12,7 +12,7 @@ def _datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
     base_dir, _ = os.path.split(test_dir)
     for ddir in ["test_x_empalc_xlsx", "test_x_empalc_csv"]:
-        dir_util.copy_tree(os.path.join(base_dir, ddir), str(tmpdir))
+        shutil.copytree(os.path.join(base_dir, ddir), str(tmpdir), dirs_exist_ok=True)
     return tmpdir
 
 

--- a/tests/test_x_ezchrom.py
+++ b/tests/test_x_ezchrom.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from distutils import dir_util
+import shutil
 from yadg.extractors.ezchrom.asc import extract as extract_asc
 from yadg.extractors.ezchrom.dat import extract as extract_dat
 import xarray as xr
@@ -12,7 +12,7 @@ def ezchrom_datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
     base_dir, _ = os.path.split(test_dir)
     for ddir in ["test_x_ezchrom_dat", "test_x_ezchrom_asc"]:
-        dir_util.copy_tree(os.path.join(base_dir, ddir), str(tmpdir))
+        shutil.copytree(os.path.join(base_dir, ddir), str(tmpdir), dirs_exist_ok=True)
     return tmpdir
 
 

--- a/tests/test_x_panalytical.py
+++ b/tests/test_x_panalytical.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from distutils import dir_util
+import shutil
 from yadg.extractors.panalytical.xrdml import extract as extract_xrdml
 from yadg.extractors.panalytical.csv import extract as extract_csv
 import xarray as xr
@@ -12,7 +12,7 @@ def _datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
     base_dir, _ = os.path.split(test_dir)
     for ddir in ["test_x_panalytical_xrdml", "test_x_panalytical_csv"]:
-        dir_util.copy_tree(os.path.join(base_dir, ddir), str(tmpdir))
+        shutil.copytree(os.path.join(base_dir, ddir), str(tmpdir), dirs_exist_ok=True)
     return tmpdir
 
 


### PR DESCRIPTION
- relax `numpy < 2.0` restriction
- move to `dgbowl-schemas >= 117`
- figure out how to support `python >= 3.9` due to pint packaging issues, see https://github.com/hgrecco/pint/issues/1974
- figure out how to support `python == 3.12` due to `distutils` removal