### PR TITLE
Dependencies and test fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,8 @@ classifiers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-    "numpy >= 1.20; python_version > '3.9'",
-    "pint >= 0.24; python_version > '3.9'",
-    "numpy >= 1.20, < 2.0; python_version == '3.9'",
-    "pint >= 0.22; python_version == '3.9'",
+    "numpy >= 1.20",
+    "pint >= 0.24.1",
     "pyyaml",
     "uncertainties",
     "striprtf",


### PR DESCRIPTION
- `pint >= 0.24.1` for compatibility with `numpy == 2.0; python_version ~= 3.9`