### PR TITLE
Ignore decode errors when trying different dtypes for mpr header

### DIFF
--- a/src/yadg/extractors/eclab/mpr.py
+++ b/src/yadg/extractors/eclab/mpr.py
@@ -552,15 +552,18 @@ def process_modules(contents: bytes) -> tuple[dict, list, list, dict, dict]:
     settings = log = loop = ext = None
     for module in modules:
         for mhd in module_header_dtypes:
-            header = dgutils.read_value(module, 0x0000, mhd)
-            if len(module) == mhd.itemsize + header["length"]:
-                version = header.get("newver", 0) + header["oldver"]
-                logger.debug(
-                    "Parsed module header with length %d, version %s",
-                    header["length"],
-                    version,
-                )
-                break
+            try:
+                header = dgutils.read_value(module, 0x0000, mhd)
+                if len(module) == mhd.itemsize + header["length"]:
+                    version = header.get("newver", 0) + header["oldver"]
+                    logger.debug(
+                        "Parsed module header with length %d, version %s",
+                        header["length"],
+                        version,
+                    )
+                    break
+            except UnicodeDecodeError:
+                continue
         else:
             raise RuntimeError("Unknown module header.")
         name = header["short_name"].strip()


### PR DESCRIPTION
@NukP had this issue with some mpr files

- read_value tries a few different possible dtypes to get header info
- If the header looks wrong, it tries the next dtype
- However this can raise an error if the dtype is wrong and it tries to decode invalid bytes
- Ignore this error and continue trying the next dtype