### PR TITLE
`eclab`: Minor tidyup.

### DIFF
--- a/src/yadg/extractors/eclab/mpr.py
+++ b/src/yadg/extractors/eclab/mpr.py
@@ -387,7 +387,6 @@ def process_data(
     version: int,
     Eranges: list[float],
     Iranges: list[float],
-    controls: list[str],
     technique: str,
 ):
     """Processes the contents of data modules.
@@ -597,14 +596,8 @@ def process_modules(contents: bytes) -> tuple[dict, list, list, dict, dict]:
             E_range_min = params.get("E range min (V)", [float("-inf")])
             Eranges = [a - b for a, b in zip(E_range_max, E_range_min)]
             Iranges = params.get("I Range", ["Auto"])
-            if "Set I/C" in params:
-                ctrls = params.get("Set I/C")
-            elif "Apply I/C" in params:
-                ctrls = params.get("Apply I/C")
-            else:
-                ctrls = [None] * len(Iranges)
         elif name == "VMP data":
-            ds = process_data(module_data, version, Eranges, Iranges, ctrls, technique)
+            ds = process_data(module_data, version, Eranges, Iranges, technique)
         elif name == "VMP LOG":
             log = process_log(module_data)
         elif name == "VMP loop":

--- a/src/yadg/extractors/eclab/mpr.py
+++ b/src/yadg/extractors/eclab/mpr.py
@@ -242,7 +242,7 @@ def process_settings(data: bytes, minver: str) -> tuple[dict, list]:
         0x1847,
     )
     for offset in offsets:
-        n_params = dgutils.read_value(data, offset + 0x0002, "<u2")
+        n_params = np.frombuffer(data, offset=offset + 0x0002, dtype="<u2", count=1)[0]
         logger.debug("Trying to find %d technique params at 0x%x.", n_params, offset)
         for dtype, versions in params_dtypes:
             logger.debug(f"{minver=} {versions=} {len(dtype)=} {n_params=}")
@@ -255,7 +255,7 @@ def process_settings(data: bytes, minver: str) -> tuple[dict, list]:
     if params_offset is None:
         raise NotImplementedError("Unknown parameter offset or technique dtype.")
     logger.debug("Reading number of parameter sequences at 0x%x.", params_offset)
-    ns = dgutils.read_value(data, params_offset, "<u2")
+    ns = np.frombuffer(data, offset=params_offset, dtype="<u2", count=1)[0]
     logger.debug("Reading %d parameter sequences of %d parameters.", ns, n_params)
     rawparams = np.frombuffer(
         data,
@@ -408,8 +408,8 @@ def process_data(
         ("u").
 
     """
-    n_datapoints = dgutils.read_value(data, 0x0000, "<u4")
-    n_columns = dgutils.read_value(data, 0x0004, "|u1")
+    n_datapoints = np.frombuffer(data, offset=0x0000, dtype="<u4", count=1)[0]
+    n_columns = np.frombuffer(data, offset=0x0004, dtype="|u1", count=1)[0]
     if version in {10, 11}:
         column_ids = np.frombuffer(data, offset=0x005, dtype=">u2", count=n_columns)
     elif version in {2, 3}:
@@ -516,7 +516,7 @@ def process_loop(data: bytes) -> dict:
         The parsed loops.
 
     """
-    n_indexes = dgutils.read_value(data, 0x0000, "<u4")
+    n_indexes = np.frombuffer(data, offset=0x0000, dtype="<u4", count=1)[0]
     indexes = np.frombuffer(data, offset=0x0004, dtype="<u4", count=n_indexes)
     return {"n_indexes": n_indexes, "indexes": indexes}
 

--- a/src/yadg/extractors/eclab/mpt.py
+++ b/src/yadg/extractors/eclab/mpt.py
@@ -223,7 +223,6 @@ def process_data(
     lines: list[str],
     Eranges: list[float],
     Iranges: list[float],
-    controls: list[str],
     locale: str,
 ):
     """Processes the data lines.
@@ -335,7 +334,6 @@ def extract_from_path(
         logger.warning("E Range not specified due to missing header, setting to 10 V.")
         Iranges = "1 A"
         logger.warning("I Range not specified due to missing header, setting to 1 A.")
-        controls = None
     else:
         header = process_header(header_lines, timezone, locale)
         start_time = header.get("uts")
@@ -346,12 +344,11 @@ def extract_from_path(
         Er_min = params.get("E range min (V)", [0.0])
         Eranges = [_max - _min for _max, _min in zip(Er_max, Er_min)]
         Iranges = params.get("I Range", ["1 A"])
-        controls = params.get("Set I/C", params.get("Apply I/C", [None] * len(Iranges)))
     # Arrange all the data into the correct format.
     # TODO: Metadata could be handled in a nicer way.
     metadata = {"settings": settings, "params": params}
 
-    ds = process_data(data_lines, Eranges, Iranges, controls, locale)
+    ds = process_data(data_lines, Eranges, Iranges, locale)
     if "time" in ds:
         ds["uts"] = ds["time"] + start_time
     else:


### PR DESCRIPTION
- Remove unused `controls` arrays.
- Replace `dgutils.read_value` with `np.frombuffer` (which it used internally anyway) when dtype is known.