### PR TITLE
Another 7.0 housekeeping

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -9,11 +9,6 @@ Units
 +++++
 In the resulting |NetCDF| files, the unit annotations are stored in ``.attrs["units"]`` on each :class:`xarray.DataArray`, that is within each "column" of each "node" of the :class:`~xarray.DataTree`. If an entry does not contain ``.attrs["units"]``, the quantity is dimensionless.
 
-.. warning::
-
-    A special :class:`pint.UnitRegistry` was exposed in ``yadg-4.x`` under :class:`yadg.dgutils.ureg`. Use of this :class:`pint.UnitRegistry` is deprecated as of ``yadg-5.0``, and it will be removed in ``yadg-6.0``.
-
-
 Uncertainties
 +++++++++++++
 In many cases it is possible to define more than one uncertainty for each measurement: for example, accuracy, precision, as well as instrument resolution etc. may be available. The convention in **yadg** is that when both a measure of within-measurement uncertainty (resolution) and a cross-measurement error (accuracy) are available, the stored uncertainty corresponds to the instrumental resolution associated with each datapoint, i.e. the resolution. The precision of the measurement (which is normally a higher value than that of the resolution) can be obtained using post-processing, e.g. as a ``mean()`` and ``stdev()`` of a series of data.

--- a/docs/source/version.7_0.rst
+++ b/docs/source/version.7_0.rst
@@ -17,6 +17,8 @@ New features in ``yadg-next`` are:
 
 Breaking changes in ``yadg-next`` are:
 
+  - For all extractors, the ``source`` (positional) argument now must be specified instead of ``fn`` or ``path``.
+
   - In :mod:`yadg.extractors.agilent.csv`, the ``signal`` data variable now has ``elution_time`` as a proper coordinate. Previously, the ``elution_time`` was expanded manually to the length of the largest trace present in the file, with ``np.nan`` used as padding for shorter traces. An arbitrary coordinate ``_`` was also present. Now, ``elution_time`` is expanded automatically by :func:`xarray.concat`, inserting ``np.nan`` into the ``signal`` data variable as necessary for ``elution_time`` which are not present in each trace.
 
 Bug fixes in ``yadg-next`` include:

--- a/src/yadg/dgutils/__init__.py
+++ b/src/yadg/dgutils/__init__.py
@@ -1,4 +1,4 @@
-from .helpers import get_yadg_metadata
+from .helpers import get_yadg_metadata, deprecated, removed
 from .dateutils import (
     now,
     infer_timestamp_from,
@@ -9,11 +9,13 @@ from .dateutils import (
 )
 from .schemautils import update_schema, schema_from_preset
 from .btools import read_value
-from .pintutils import sanitize_units, ureg
+from .pintutils import sanitize_units
 from .dsutils import dicts_to_dataset, append_dicts, merge_dicttrees, merge_meta
 
 __all__ = [
     "get_yadg_metadata",
+    "deprecated",
+    "removed",
     "now",
     "infer_timestamp_from",
     "str_to_uts",
@@ -24,7 +26,6 @@ __all__ = [
     "schema_from_preset",
     "read_value",
     "sanitize_units",
-    "ureg",
     "dicts_to_dataset",
     "append_dicts",
     "merge_dicttrees",

--- a/src/yadg/dgutils/helpers.py
+++ b/src/yadg/dgutils/helpers.py
@@ -23,3 +23,13 @@ def deprecated(arg, depin="4.2", depout="5.0") -> None:
         stacklevel=2,
     )
     warnings.simplefilter("default", DeprecationWarning)
+
+
+def removed(arg, depout="7.0") -> None:
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        f"'{arg}' has been removed in yadg-{depout}, please check release notes",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)

--- a/src/yadg/dgutils/pintutils.py
+++ b/src/yadg/dgutils/pintutils.py
@@ -1,47 +1,17 @@
 """
 ``pint`` compatibility functions in **yadg**.
 
-This package defines ``ureg``, a :class:`pint.UnitRegistry` used for validation of
-`datagrams` in **yadg**. The default SI :class:`pint.UnitRegistry` is extended
-by definitions of fractional quantities (%, ppm, etc.), standard volumetric
-quantities (smL/min, sccm), and other dimensionless "units" present in several
-file types.
+This module contains the unit sanitizer to make some common unit spelling
+variants compatible with :mod:`pint`.
 """
 
 import logging
-import pint
 
 logger = logging.getLogger(__name__)
 
-ureg = pint.UnitRegistry(
-    preprocessors=[
-        lambda s: s.replace("%%", " permille "),
-        lambda s: s.replace("%", " percent "),
-    ]
-)
-
-definitions = """
-parts_per_hundred = 1e-2 count = percent
-parts_per_thousand = 1e-3 count = ‰ = promile = permille
-parts_per_million = 1e-6 count = ppm
-parts_per_billion = 1e-9 count = ppb
-
-standard_milliliter = milliliter = smL
-standard_liter = liter = sL
-standard_cubic_centimeter_minute = cm^3/min = sccm
-
-refractive_index_units = [] = RIU
-"""
-
-for line in definitions.split("\n"):
-    line = line.strip()
-    if len(line) > 0 and not line.startswith("#"):
-        ureg.define(line)
-
-
 def _sanitize_helper(unit: str) -> str:
     unit = unit.replace("Bar", "bar")
-    if unit in ["deg C", "Deg C"]:
+    if unit in {"deg C", "Deg C"}:
         return "degC"
     else:
         return unit
@@ -58,7 +28,7 @@ def sanitize_units(
     replacements are done:
 
       - "Bar" is replaced with "bar"
-      - "Deg C" is replace with "degC
+      - "Deg C" is replaced with "degC
 
     Use with caution.
 
@@ -69,11 +39,9 @@ def sanitize_units(
 
     """
     if isinstance(units, list):
-        for i in range(len(units)):
-            units[i] = _sanitize_helper(units[i])
+        units = [_sanitize_helper(i) for i in units]
     elif isinstance(units, dict):
-        for k, v in units.items():
-            units[k] = _sanitize_helper(v)
+        units = {k: _sanitize_helper(v) for k, v in units.items()}
     elif isinstance(units, str):
         units = _sanitize_helper(units)
     else:

--- a/src/yadg/dgutils/pintutils.py
+++ b/src/yadg/dgutils/pintutils.py
@@ -9,6 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def _sanitize_helper(unit: str) -> str:
     unit = unit.replace("Bar", "bar")
     if unit in {"deg C", "Deg C"}:

--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -14,22 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 def deprecate_fn_path(func):
-    def handle_deprecated(param, *args, **kwargs):
-        logger.warning(
-            f"The parameter '{param}' is deprecated and has been replaced by 'source'. ({DeprecationWarning.__name__})",
-        )
-        source = kwargs.get("source", kwargs.pop(param))
-        args = (source,) + args
-        return args, kwargs
-
     @wraps(func)
     def wrapper(*args, **kwargs):
         if kwargs.get("source") is not None:
             args = (kwargs.pop("source"),) + args
         elif kwargs.get("fn") is not None:
-            args, kwargs = handle_deprecated("fn", *args, **kwargs)
+            dgutils.removed("fn", depout="7.0")
         elif kwargs.get("path") is not None:
-            args, kwargs = handle_deprecated("path", *args, **kwargs)
+            dgutils.removed("path", depout="7.0")
         return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
- remove `ureg`
- remove deprecated `fn` and `path` arguments to extractors