### PR TITLE
Add temperature resolution

### DIFF
--- a/src/yadg/extractors/eclab/techniques.py
+++ b/src/yadg/extractors/eclab/techniques.py
@@ -1789,6 +1789,8 @@ def dev_derived(
         # εr = ε/ε0
         # ε -> [F]/[m] = [A]*[s]/[V]
         return val * rtol_VI
+    elif unit in {"°C"}:
+        return 1e-6  # Based on quantization error in measurements
     else:
         raise RuntimeError(
             f"Could not get resolution of quantity {name!r} with unit {unit!r}."


### PR DESCRIPTION
Very small change - adds a temperature resolution to avoid a RunTimeError

The resolution is based of quantization error when measuring temperature with a BCS-815, and is far smaller than the statistical noise, which is more like 0.1°C, but I guess depends on the exact set up.

I would also be fine setting it to nan - maybe this should be the default if the unit isn't in the list?