### PR TITLE
Bugfix `extract_from_bytes`

### DIFF
--- a/src/yadg/extractors/__init__.py
+++ b/src/yadg/extractors/__init__.py
@@ -144,7 +144,7 @@ def extract_from_bytes(
     func = getattr(m, "extract")
 
     # Func should always return a xarray.DataTree
-    ret: DataTree = func(source=source, **vars(extractor))
+    ret: DataTree = func(source, **vars(extractor), **kwargs)
     jsonize_orig_meta(ret)
 
     ret.attrs.update(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -42,7 +42,13 @@ def test_yadg__extractors_extract_str(datadir):
 def test_yadg_extractors_extract_from_bytes(datadir):
     """Regression test for extract_from_bytes."""
     os.chdir(datadir)
-    extractor = ExtractorFactory(extractor={"filetype": "eclab.mpr"}).extractor
+    extractor = ExtractorFactory(
+        extractor={
+            "filetype": "eclab.mpr",
+            "timezone": "Europe/Berlin",
+            "locale": "en_GB",
+        }
+    ).extractor
     with open("cp.mpr", "rb") as f:
         source = f.read()
     ret = extract_from_bytes(source=source, extractor=extractor)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,6 +1,7 @@
 import pytest
 import os
-from yadg.extractors import extract
+from dgbowl_schemas.yadg.dataschema import ExtractorFactory
+from yadg.extractors import extract, extract_from_bytes
 import xarray as xr
 from pathlib import Path
 from .utils import compare_datatrees
@@ -36,3 +37,14 @@ def test_yadg__extractors_extract_str(datadir):
     """Extract accepts a str path."""
     os.chdir(datadir)
     extract("eclab.mpr", "cp.mpr")
+
+
+def test_yadg_extractors_extract_from_bytes(datadir):
+    """Regression test for extract_from_bytes."""
+    os.chdir(datadir)
+    extractor = ExtractorFactory(extractor={"filetype": "eclab.mpr"}).extractor
+    with open("cp.mpr", "rb") as f:
+        source = f.read()
+    ret = extract_from_bytes(source=source, extractor=extractor)
+    ref = xr.open_datatree("cp.mpr.nc", engine="h5netcdf")
+    compare_datatrees(ret, ref, thislevel=True, descend=True)


### PR DESCRIPTION
Whenever you use `extract_from_bytes` in 7.0 you get an error "TypeError: extract requires at least 1 positional argument".

`deprecate_fn_path` used to change source into a positional argument. That was dropped, but `extract_from_bytes` was still passing `func(source=source, ...`

Changed it to  `func(source, ...` like `extract` (also added `**kwargs` because it was unused, not sure if that is intentional).

Added a regression test which runs `extract_from_bytes` on one mpr file.